### PR TITLE
Restore logistic regression model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cache/
+data.csv
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# f1-test
+# F1 Winner Predictor
+
+This project downloads Formula 1 race results with the
+[FastF1](https://github.com/theOehrly/Fast-F1) library and trains a logistic
+regression model to estimate each driver's chance of winning the next race. The
+model is trained on data from the last few seasons and uses cross-validation to
+improve accuracy.
+
+## Setup
+
+Install the dependencies with pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+The first run will download timing data from the official F1 API and cache it in
+`cache/`.
+
+If `data.csv` is not present, race results from the past three seasons will also
+be downloaded automatically to build the training dataset.
+
+## Usage
+
+1. Run `predict_winner.py` to fetch race results, train a model and display the
+   predicted winner for the most recent round.
+
+```bash
+python predict_winner.py
+```
+
+The script also prints the overall accuracy of the model using a random train
+/test split.
+
+## Data Source
+
+Race and timing data is retrieved via `fastf1`, which accesses the official F1
+live timing API. No deprecated Ergast data is used.

--- a/predict_winner.py
+++ b/predict_winner.py
@@ -1,0 +1,137 @@
+import fastf1
+import pandas as pd
+from pathlib import Path
+
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.compose import ColumnTransformer
+from sklearn.pipeline import Pipeline
+from sklearn.linear_model import LogisticRegressionCV
+
+CACHE_DIR = Path("cache")
+CACHE_DIR.mkdir(exist_ok=True)
+fastf1.Cache.enable_cache(str(CACHE_DIR))
+
+
+def load_data(years=(2022, 2023, 2024)):
+    """Load race results for multiple seasons using FastF1.
+
+    If a cached CSV file exists it will be reused to avoid excessive
+    network access.
+    """
+    csv_path = Path("data.csv")
+    if csv_path.exists():
+        return pd.read_csv(csv_path)
+
+    records = []
+    for year in years:
+        schedule = fastf1.get_event_schedule(year, include_testing=False)
+        for rnd in schedule["RoundNumber"]:
+            try:
+                session = fastf1.get_session(year, int(rnd), "R")
+                session.load(laps=False, telemetry=False)
+            except Exception as exc:  # pragma: no cover - network errors
+                print(f"Could not load {year} round {rnd}: {exc}")
+                continue
+
+            res = session.results[
+                [
+                    "DriverNumber",
+                    "Abbreviation",
+                    "TeamName",
+                    "GridPosition",
+                    "Position",
+                    "Points",
+                ]
+            ].copy()
+            res["Year"] = year
+            res["Round"] = int(rnd)
+            records.append(res)
+
+    df = pd.concat(records, ignore_index=True)
+    df = df.dropna(subset=["GridPosition", "DriverNumber", "Position"])
+    df.to_csv(csv_path, index=False)
+    return df
+
+
+def build_model():
+    """Return a logistic regression model with basic preprocessing."""
+
+    categorical = ["Abbreviation", "TeamName"]
+    numeric = ["GridPosition", "DriverNumber"]
+
+    pre = ColumnTransformer(
+        [
+            ("cat", OneHotEncoder(handle_unknown="ignore"), categorical),
+            ("num", StandardScaler(), numeric),
+        ]
+    )
+
+    model = Pipeline(
+        [
+            ("preprocess", pre),
+            (
+                "classifier",
+                LogisticRegressionCV(
+                    Cs=10,
+                    cv=5,
+                    max_iter=5000,
+                    scoring="accuracy",
+                    n_jobs=None,
+                ),
+            ),
+        ]
+    )
+    return model
+
+
+def train_and_predict():
+    df = load_data()
+    df["Winner"] = (df["Position"] == 1).astype(int)
+
+    last_year = df["Year"].max()
+    last_round = df[df["Year"] == last_year]["Round"].max()
+
+    train_df = df[~((df["Year"] == last_year) & (df["Round"] == last_round))]
+    test_df = df[(df["Year"] == last_year) & (df["Round"] == last_round)]
+
+    X_train = train_df[[
+        "Abbreviation",
+        "TeamName",
+        "GridPosition",
+        "DriverNumber",
+    ]]
+    y_train = train_df['Winner']
+
+    model = build_model()
+    model.fit(X_train, y_train)
+
+    X_test = test_df[[
+        "Abbreviation",
+        "TeamName",
+        "GridPosition",
+        "DriverNumber",
+    ]]
+    probs = model.predict_proba(X_test)[:, 1]
+    test_df = test_df.copy()
+    test_df['WinProbability'] = probs
+    pred = test_df.sort_values('WinProbability', ascending=False).iloc[0]
+    print("Predicted winner for round", last_round, "is", pred['Abbreviation'],
+          "with probability", f"{pred['WinProbability']:.3f}")
+    actual_winner = test_df[test_df['Winner'] == 1].iloc[0]
+    print("Actual winner was", actual_winner['Abbreviation'])
+
+    # compute accuracy on full dataset via train/test split
+    X = df[["Abbreviation", "TeamName", "GridPosition", "DriverNumber"]]
+    y = df['Winner']
+    X_tr, X_te, y_tr, y_te = train_test_split(
+        X, y, test_size=0.2, stratify=y, random_state=42
+    )
+    model = build_model()
+    model.fit(X_tr, y_tr)
+    acc = model.score(X_te, y_te)
+    print("Overall accuracy", f"{acc:.3f}")
+
+
+if __name__ == '__main__':
+    train_and_predict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastf1
+pandas
+scikit-learn
+numpy
+matplotlib


### PR DESCRIPTION
## Summary
- restore logistic regression pipeline and remove random forest
- mention logistic regression again in README
- ensure cache directory exists before enabling FastF1 caching

## Testing
- `flake8`
- `python predict_winner.py | head -n 3` *(fails due to long network call and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6888fb37ea0883218c1bcba60f48d70a