### PR TITLE
Integrate playwright for f1-winner automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 cache/
 data.csv
 __pycache__/
+node_modules/
+playwright-report/
+test-results/
+playwright/artifacts/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,40 @@ The script also prints the overall accuracy of the model using a random train
 /test split. It then estimates the winner of the next scheduled race using the
 current driver and team standings.
 
+## Playwright Automation Suite
+
+The `playwright/` workspace showcases the end-to-end and scraping tests I built
+to validate selectors, page objects and asynchronous user flows without needing
+access to the live timing service.
+
+### Run the tests
+
+```bash
+cd playwright
+npm install
+npx playwright install --with-deps  # first run only
+npm test
+```
+
+What the suite covers:
+
+- parsing the mock live-timing table and asserting the structured results can
+  feed downstream ML features
+- exercising filter controls and empty states to catch edge cases in selectors
+- awaiting async refresh flows (spinner, disabled buttons, fresh data rows)
+
+### Capture results via Playwright
+
+The same page object powers a small scraper that persists structured race
+results for experimentation with the Python model:
+
+```bash
+cd playwright
+npm run scrape
+```
+
+JSON output is written to `playwright/artifacts/mock-results.json`.
+
 ## Data Source
 
 Race and timing data is retrieved via `fastf1`, which accesses the official F1

--- a/playwright/fixtures/mock_results.html
+++ b/playwright/fixtures/mock_results.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Mock F1 Race Results</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background-color: #0f111a;
+      color: #f5f7ff;
+    }
+
+    body {
+      margin: 0;
+      padding: 2rem;
+    }
+
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      background: #141724;
+      border-radius: 18px;
+      padding: 2rem;
+      box-shadow: 0 25px 80px rgba(10, 12, 26, 0.35);
+    }
+
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 0.4rem;
+    }
+
+    .subhead {
+      margin-top: 0;
+      color: #a1a6c8;
+    }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: flex-end;
+      margin-bottom: 1rem;
+    }
+
+    label {
+      font-size: 0.9rem;
+      color: #a1a6c8;
+    }
+
+    input {
+      width: 240px;
+      padding: 0.6rem;
+      border-radius: 10px;
+      border: 1px solid #2e3350;
+      background: #0d101c;
+      color: inherit;
+      margin-top: 0.3rem;
+    }
+
+    button {
+      border: none;
+      border-radius: 999px;
+      padding: 0.6rem 1.4rem;
+      font-weight: 600;
+      background: linear-gradient(120deg, #ff6b6b, #845ef7);
+      color: #fff;
+      cursor: pointer;
+      transition: opacity 150ms ease;
+    }
+
+    button.secondary {
+      background: transparent;
+      border: 1px solid #2e3350;
+    }
+
+    button:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 0.75rem;
+    }
+
+    th,
+    td {
+      text-align: left;
+      padding: 0.65rem;
+    }
+
+    thead {
+      background: #171a2b;
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      letter-spacing: 0.08rem;
+    }
+
+    tbody tr {
+      border-bottom: 1px solid #1f2336;
+      transition: background 150ms ease;
+    }
+
+    tbody tr:hover {
+      background: rgba(255, 255, 255, 0.04);
+    }
+
+    .chip {
+      border-radius: 999px;
+      padding: 0.2rem 0.75rem;
+      font-weight: 600;
+      font-size: 0.8rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    .empty {
+      margin-top: 1rem;
+      padding: 1rem;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px dashed #2e3350;
+      color: #a1a6c8;
+    }
+
+    .status {
+      margin: 0.5rem 0 0;
+      font-size: 0.9rem;
+      color: #8be9fd;
+    }
+
+    .is-hidden {
+      display: none !important;
+    }
+  </style>
+</head>
+
+<body>
+  <main>
+    <header>
+      <p class="eyebrow">Automation Playground</p>
+      <h1 data-testid="page-title">2024 Live Timing Snapshot</h1>
+      <p class="subhead">Used to validate selectors, page objects, and assertions for the Playwright test suite.</p>
+    </header>
+
+    <section class="controls">
+      <label>
+        Filter by driver or abbreviation
+        <input id="driver-filter" data-testid="driver-filter" placeholder="Try 'VER' or 'Ferrari'" autocomplete="off" />
+      </label>
+      <button class="secondary" data-testid="clear-filter" type="button">Clear filter</button>
+      <button data-testid="refresh-button" type="button">Refresh classification</button>
+    </section>
+
+    <p class="status" data-testid="status-banner" data-state="idle">Standing data ready</p>
+
+    <table data-testid="results-table">
+      <thead>
+        <tr>
+          <th>Round</th>
+          <th>Grand Prix</th>
+          <th>Driver</th>
+          <th>Team</th>
+          <th>Grid</th>
+          <th>Finish</th>
+          <th>Points</th>
+        </tr>
+      </thead>
+      <tbody data-testid="results-body">
+        <tr data-testid="result-row" data-driver="max verstappen ver red bull" data-round="1">
+          <td>1</td>
+          <td>Bahrain GP</td>
+          <td>
+            <span class="chip">VER</span> Max Verstappen
+          </td>
+          <td>Oracle Red Bull Racing</td>
+          <td>1</td>
+          <td>1</td>
+          <td>26</td>
+        </tr>
+        <tr data-testid="result-row" data-driver="charles leclerc lec ferrari" data-round="2">
+          <td>2</td>
+          <td>Saudi Arabian GP</td>
+          <td>
+            <span class="chip">LEC</span> Charles Leclerc
+          </td>
+          <td>Scuderia Ferrari</td>
+          <td>1</td>
+          <td>1</td>
+          <td>26</td>
+        </tr>
+        <tr data-testid="result-row" data-driver="oscar piastri pia mclaren" data-round="3">
+          <td>3</td>
+          <td>Australian GP</td>
+          <td>
+            <span class="chip">PIA</span> Oscar Piastri
+          </td>
+          <td>McLaren F1 Team</td>
+          <td>2</td>
+          <td>1</td>
+          <td>26</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="empty is-hidden" data-testid="empty-state">
+      No drivers match "<span data-testid="empty-query"></span>". Try a different filter.
+    </p>
+  </main>
+
+  <script>
+    (function () {
+      const filterInput = document.querySelector('[data-testid="driver-filter"]');
+      const clearButton = document.querySelector('[data-testid="clear-filter"]');
+      const rows = () => Array.from(document.querySelectorAll('[data-testid="result-row"]'));
+      const emptyState = document.querySelector('[data-testid="empty-state"]');
+      const emptyQuery = document.querySelector('[data-testid="empty-query"]');
+      const statusBanner = document.querySelector('[data-testid="status-banner"]');
+      const refreshButton = document.querySelector('[data-testid="refresh-button"]');
+      const body = document.querySelector('[data-testid="results-body"]');
+
+      function applyFilter() {
+        const query = filterInput.value.trim().toLowerCase();
+        let visibleCount = 0;
+
+        rows().forEach((row) => {
+          const matches = query.length === 0 || row.dataset.driver.includes(query);
+          row.classList.toggle('is-hidden', !matches);
+          if (matches) {
+            visibleCount += 1;
+          }
+        });
+
+        emptyState.classList.toggle('is-hidden', visibleCount !== 0);
+        emptyQuery.textContent = query || 'all drivers';
+      }
+
+      filterInput.addEventListener('input', applyFilter);
+      clearButton.addEventListener('click', () => {
+        filterInput.value = '';
+        applyFilter();
+        filterInput.focus();
+      });
+
+      refreshButton.addEventListener('click', () => {
+        if (refreshButton.disabled) {
+          return;
+        }
+
+        statusBanner.dataset.state = 'loading';
+        statusBanner.textContent = 'Loading latest classification...';
+        refreshButton.disabled = true;
+
+        setTimeout(() => {
+          const existing = document.querySelector('[data-round="11"]');
+          if (!existing) {
+            const row = document.createElement('tr');
+            row.setAttribute('data-testid', 'result-row');
+            row.dataset.driver = 'lando norris nor mclaren';
+            row.dataset.round = '11';
+            row.innerHTML = `
+              <td>11</td>
+              <td>Miami GP</td>
+              <td><span class="chip">NOR</span> Lando Norris</td>
+              <td>McLaren F1 Team</td>
+              <td>5</td>
+              <td>1</td>
+              <td>25</td>
+            `;
+            body.prepend(row);
+          }
+
+          statusBanner.dataset.state = 'idle';
+          statusBanner.textContent = 'Updated from live timing';
+          refreshButton.disabled = false;
+          applyFilter();
+        }, 650);
+      });
+
+      applyFilter();
+    })();
+  </script>
+</body>
+
+</html>

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -1,0 +1,637 @@
+{
+  "name": "f1-winner-playwright",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "f1-winner-playwright",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "playwright": "^1.49.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "f1-winner-playwright",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright automation suite for the F1 winner predictor project.",
+  "scripts": {
+    "test": "playwright test",
+    "scrape": "tsx src/scrapeResults.ts",
+    "lint": "playwright test --list"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "playwright": "^1.49.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+
+const projectRoot = path.resolve(__dirname);
+
+export default defineConfig({
+  testDir: path.join(projectRoot, 'tests'),
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  metadata: {
+    project: 'f1-winner-playwright',
+  },
+});

--- a/playwright/src/page-objects/RaceResultsPage.ts
+++ b/playwright/src/page-objects/RaceResultsPage.ts
@@ -1,0 +1,105 @@
+import path from 'path';
+import { pathToFileURL } from 'url';
+import type { Locator, Page } from 'playwright';
+
+export type RaceResult = {
+  round: number;
+  grandPrix: string;
+  driver: string;
+  abbreviation: string;
+  team: string;
+  grid: number;
+  finish: number;
+  points: number;
+};
+
+const defaultFixturePath = path.resolve(__dirname, '../../fixtures/mock_results.html');
+
+export class RaceResultsPage {
+  private readonly page: Page;
+  private readonly fixturePath: string;
+
+  readonly title: Locator;
+  readonly filterInput: Locator;
+  readonly clearFilterButton: Locator;
+  readonly refreshButton: Locator;
+  readonly statusBanner: Locator;
+  readonly emptyState: Locator;
+  readonly rows: Locator;
+  readonly visibleRows: Locator;
+
+  constructor(page: Page, fixtureOverride?: string) {
+    this.page = page;
+    this.fixturePath = fixtureOverride ?? defaultFixturePath;
+
+    this.title = page.getByTestId('page-title');
+    this.filterInput = page.getByTestId('driver-filter');
+    this.clearFilterButton = page.getByTestId('clear-filter');
+    this.refreshButton = page.getByTestId('refresh-button');
+    this.statusBanner = page.getByTestId('status-banner');
+    this.emptyState = page.getByTestId('empty-state');
+    this.rows = page.getByTestId('result-row');
+    this.visibleRows = page.locator('[data-testid="result-row"]:not(.is-hidden)');
+  }
+
+  async goto() {
+    const fileUrl = pathToFileURL(this.fixturePath).href;
+    await this.page.goto(fileUrl);
+  }
+
+  async filterByDriver(query: string) {
+    await this.filterInput.fill(query);
+  }
+
+  async clearFilter() {
+    await this.clearFilterButton.click();
+  }
+
+  async triggerRefresh() {
+    await this.refreshButton.click();
+  }
+
+  async extractResults(): Promise<RaceResult[]> {
+    return this.rows.evaluateAll((elements) =>
+      elements.map((row) => {
+        const cells = Array.from(row.querySelectorAll('td')).map((cell) =>
+          cell.textContent?.trim() ?? ''
+        );
+        const driverCell = row.querySelector('td:nth-child(3)')?.textContent ?? '';
+        const abbreviation = (row.querySelector('.chip')?.textContent ?? '').trim();
+        return {
+          round: Number(cells[0]),
+          grandPrix: cells[1],
+          driver: driverCell.replace(abbreviation, '').trim(),
+          abbreviation,
+          team: cells[3],
+          grid: Number(cells[4]),
+          finish: Number(cells[5]),
+          points: Number(cells[6]),
+        };
+      })
+    );
+  }
+
+  async extractVisibleResults(): Promise<RaceResult[]> {
+    return this.visibleRows.evaluateAll((elements) =>
+      elements.map((row) => {
+        const cells = Array.from(row.querySelectorAll('td')).map((cell) =>
+          cell.textContent?.trim() ?? ''
+        );
+        const abbreviation = (row.querySelector('.chip')?.textContent ?? '').trim();
+        const driverCell = row.querySelector('td:nth-child(3)')?.textContent ?? '';
+        return {
+          round: Number(cells[0]),
+          grandPrix: cells[1],
+          driver: driverCell.replace(abbreviation, '').trim(),
+          abbreviation,
+          team: cells[3],
+          grid: Number(cells[4]),
+          finish: Number(cells[5]),
+          points: Number(cells[6]),
+        };
+      })
+    );
+  }
+}

--- a/playwright/src/scrapeResults.ts
+++ b/playwright/src/scrapeResults.ts
@@ -1,0 +1,26 @@
+import { chromium } from 'playwright';
+import path from 'path';
+import { promises as fs } from 'fs';
+import { RaceResultsPage } from './page-objects/RaceResultsPage';
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const raceResults = new RaceResultsPage(page);
+
+  await raceResults.goto();
+  const rows = await raceResults.extractResults();
+
+  const artifactDir = path.resolve(__dirname, '../artifacts');
+  await fs.mkdir(artifactDir, { recursive: true });
+  const artifactPath = path.join(artifactDir, 'mock-results.json');
+  await fs.writeFile(artifactPath, JSON.stringify(rows, null, 2), 'utf-8');
+
+  console.log(`Saved ${rows.length} race results to ${artifactPath}`);
+  await browser.close();
+}
+
+main().catch((error) => {
+  console.error('Unable to scrape mock results', error);
+  process.exit(1);
+});

--- a/playwright/tests/race-results.spec.ts
+++ b/playwright/tests/race-results.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import { RaceResultsPage } from '../src/page-objects/RaceResultsPage';
+
+test.describe('f1-winner Playwright automation', () => {
+  test('extracts mock race results for downstream model features', async ({ page }) => {
+    const raceResults = new RaceResultsPage(page);
+    await raceResults.goto();
+
+    await expect(raceResults.title).toHaveText(/2024 Live Timing Snapshot/);
+    const rows = await raceResults.extractResults();
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      round: 1,
+      grandPrix: 'Bahrain GP',
+      driver: 'Max Verstappen',
+      abbreviation: 'VER',
+    });
+  });
+
+  test('filters the table via selectors and exposes empty states', async ({ page }) => {
+    const raceResults = new RaceResultsPage(page);
+    await raceResults.goto();
+
+    await raceResults.filterByDriver('Ferrari');
+    const ferrariRows = await raceResults.extractVisibleResults();
+    expect(ferrariRows).toHaveLength(1);
+    expect(ferrariRows[0].team).toContain('Ferrari');
+
+    await raceResults.filterByDriver('HAM');
+    await expect(raceResults.visibleRows).toHaveCount(0);
+    await expect(raceResults.emptyState).toBeVisible();
+
+    await raceResults.clearFilter();
+    await expect(raceResults.visibleRows).toHaveCount(3);
+  });
+
+  test('waits for asynchronous refresh state to capture new winners', async ({ page }) => {
+    const raceResults = new RaceResultsPage(page);
+    await raceResults.goto();
+
+    await raceResults.triggerRefresh();
+    await expect(raceResults.statusBanner).toHaveAttribute('data-state', 'loading');
+    await expect(raceResults.statusBanner).toHaveText(/Loading latest classification/);
+
+    const norrisRow = raceResults.rows.filter({ hasText: 'Lando Norris' });
+    await expect(norrisRow).toHaveCount(1);
+    await expect(raceResults.statusBanner).toHaveAttribute('data-state', 'idle');
+    await expect(raceResults.visibleRows).toHaveCount(4);
+  });
+});

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "@playwright/test"],
+    "baseUrl": ".",
+    "paths": {
+      "@page-objects/*": ["src/page-objects/*"]
+    }
+  },
+  "include": ["playwright.config.ts", "tests", "src"]
+}


### PR DESCRIPTION
Introduce a Playwright automation suite to demonstrate E2E and scraping capabilities, validate UI interactions, and provide structured data for the ML model.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cd80515-b6eb-46e0-a31b-cdb18942a9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2cd80515-b6eb-46e0-a31b-cdb18942a9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Playwright workspace with E2E tests, a mock live‑timing fixture, a page object and a scraper that exports structured results, plus docs and ignore updates.
> 
> - **Automation (Playwright)**:
>   - **Workspace**: New `playwright/` project with `playwright.config.ts` and TypeScript setup (`tsconfig.json`).
>   - **Page Object**: `src/page-objects/RaceResultsPage.ts` to navigate fixture, filter/clear, refresh, and extract structured `RaceResult` rows.
>   - **Tests**: `tests/race-results.spec.ts` validating result extraction, filter/empty states, and async refresh inserting a new winner row.
>   - **Scraper**: `src/scrapeResults.ts` writes JSON to `playwright/artifacts/mock-results.json`.
>   - **Fixture**: `fixtures/mock_results.html` mock results table with filter controls and refresh behavior.
> - **Docs**: `README.md` adds instructions for running tests and scraping results.
> - **Tooling**: `playwright/package.json` with `test`, `scrape`, and `lint` scripts and Playwright/TypeScript dev deps.
> - **Repo**: `.gitignore` updated for `node_modules/` and Playwright outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 938797d1caa856371a30d0f75c58985fb9e74f7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->