### PR TITLE
Add telemetry overlay and data-driven session replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ model_cache.pkl
 last_predictions.pkl
 .apex_ai.lock
 radio_cache/
+replay_cache/
 schedule_cache.json
 *.pyc
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # ApexAI — F1 Race Predictor
 
-ApexAI is an end-to-end Formula 1 race prediction suite. It ingests
-timing data with [FastF1](https://github.com/theOehrly/Fast-F1), trains
-a three-model soft-voting ensemble on five seasons of race history
-(2022 – 2026 mid-season), and presents calibrated win probabilities for
-the next race inside a custom Tk + PIL desktop app styled like a
-pit-wall racing console — complete with a broadcast-style podium,
-per-circuit ambient theming, live FIA team-radio playback, and
-one-click race replays for every session of every round.
+ApexAI is an end-to-end Formula 1 race prediction *and telemetry* suite.
+It ingests timing data with
+[FastF1](https://github.com/theOehrly/Fast-F1), trains a three-model
+soft-voting ensemble on five seasons of race history (2022 – 2026
+mid-season), and presents calibrated win probabilities for the next race
+inside a custom Tk + PIL desktop app styled like a pit-wall racing
+console — complete with a broadcast-style podium, per-circuit ambient
+theming, live FIA team-radio playback, one-click race replays for every
+session of every round, a lap-vs-lap telemetry overlay, and a fully
+scrubbable data-driven replay of any session since 2018.
 
 ![ApexAI racing-console GUI — v6 ensemble predictions](screenshot.png)
 
@@ -59,9 +61,10 @@ one-click race replays for every session of every round.
   latest completed weekend.
 - **Racing-console GUI** (`app.py`) — Tk + PIL interface styled like a
   steering-wheel / pit-wall console: a telemetry header cluster with a
-  pulsing SYS LED, live session clock, and model/accuracy readouts; five
+  pulsing SYS LED, live session clock, and model/accuracy readouts; seven
   numbered console-button tabs (*01 Predict*, *02 Backtest*,
-  *03 Visualization*, *04 Team Radio*, *05 Replays*) with red engaged
+  *03 Visualization*, *04 Team Radio*, *05 Replays*, *06 Telemetry*,
+  *07 Session Replay*) with red engaged
   light-bars; monospace telemetry fonts throughout; a carbon-fiber cap
   strip; and a timing-bar footer — plus a one-click *Refresh* to
   retrain on the latest data.
@@ -94,6 +97,30 @@ one-click race replays for every session of every round.
   [fullraces.com](https://fullraces.com). Pick a season, click *Race* /
   *Qualifying* / *Sprint* / *Sprint Quali* / *Practice* and the
   replay opens in your default browser.
+- **Telemetry overlay** (`telemetry.py` + *06 Telemetry*) — put any two
+  laps side by side on a shared distance axis: speed, throttle, brake,
+  DRS and gear traces, a running time delta, and a mini-sector
+  dominance map showing exactly where each lap was won. Alignment is by
+  *distance around the lap* rather than by clock, so the two laps do not
+  have to come from the same session — **lap vs lap**, **compound vs
+  compound** and **year vs year** are all the same feature. Turn off
+  *LINK SESSIONS* to reach across weekends and seasons.
+- **Session replay** (*07 Session Replay*) — a real, data-driven replay
+  of any session from 2018 onwards, rebuilt from FastF1's position and
+  car-telemetry streams:
+  - **Live track map** traced from the session's own position data, with
+    numbered corners and every car moving in real time.
+  - **Timing screen** with running order, gap to the leader, current lap,
+    tyre compound and rolling personal best. Races are ordered by track
+    position (each car projected onto the circuit centreline for a true
+    live order); qualifying and practice are ordered by best lap, exactly
+    like the real broadcast screens.
+  - **Telemetry HUD** for the focused car — speed, gear, throttle/brake
+    bars, RPM, DRS and tyre. Click any timing row to follow that driver.
+  - **Transport controls** — play/pause, 0.5× → 16× playback, scrub bar,
+    and ±1 lap jumps.
+  - Built replays are cached to `replay_cache/`, so re-opening a session
+    you have already watched is instant.
 
 ## Setup
 
@@ -130,6 +157,13 @@ the podium card + win probabilities for the next round. From there:
   driver, lap-mapped from the FIA archive.
 - **Race Replays** — One-click links to FullRaces.com for every
   session of every round, by season.
+- **Telemetry** — Pick a season, round and session, then a driver and
+  lap on each side, and hit *Compare Laps*. Leave *LINK SESSIONS* on to
+  compare two drivers in the same session; turn it off to compare across
+  sessions or seasons.
+- **Session Replay** — Pick a session and hit *Load Replay*. The first
+  load for a session downloads its telemetry stream (a minute or so on a
+  race); after that it comes straight from `replay_cache/`.
 - **F1 / ApexAI logo (header)** — Click anywhere on the brand mark to
   jump back to the predictions view.
 
@@ -158,9 +192,12 @@ at small sizes (grid rows, podium) for legibility.
 ## Project layout
 
 ```
-app.py            Tk + PIL desktop app (GUI, viz, radio, replays)
+app.py            Tk + PIL desktop app (GUI, viz, radio, replays,
+                  telemetry overlay, session replay)
 prediction.py     Data ingest, feature engineering, model training,
                   caching, singleton enforcement, and inference
+telemetry.py      Telemetry + session-replay data layer: lap traces,
+                  distance alignment / delta, and replay frame building
 predict_winner.py Headless CLI entry point
 radio_fia.py      FIA livetiming archive client for full-race radio
 team_colors.py    Official team-colour palette
@@ -184,6 +221,10 @@ Produces `dist/F1 Winner Predictor.app`. Data and cache live in
 
 - **Race + timing data** — `fastf1`, talking to the official F1 live
   timing API.
+- **Telemetry + session replay** — the same FastF1 feed's car-data and
+  position streams (`Speed`, `Throttle`, `Brake`, `nGear`, `RPM`, `DRS`,
+  `X`/`Y`). These only exist from 2018 onwards, which is why the
+  telemetry and replay season selectors stop there.
 - **Team radio** — FIA livetiming archive (`TeamRadio.json` +
   `TeamRadio.jsonStream`) with OpenF1 as a fallback.
 - **Race replays** — [fullraces.com](https://fullraces.com), reached

--- a/app.py
+++ b/app.py
@@ -60,6 +60,16 @@ from team_colors import TEAM_COLORS
 from team_logos import load_logo
 from track_layouts import get_track
 
+# Telemetry + session-replay data layer.  Imported defensively so a missing
+# FastF1 build degrades to "those two tabs are unavailable" rather than
+# taking the whole app down on launch.
+try:
+    import telemetry as teldata
+    HAS_TELEMETRY = True
+except Exception:
+    teldata = None
+    HAS_TELEMETRY = False
+
 try:
     import f1radio
     HAS_F1RADIO = True
@@ -1160,6 +1170,20 @@ class ApexAI:
         self._race_idx = -1
         self._season_driver_pts = {}
         self._season_team_pts = {}
+        # Session pickers (season / round / session) are shared between the
+        # Telemetry and Replay tabs; each one namespaces its widgets here.
+        self._pickers = {}
+        self._telemetry_built = False
+        self._replay_built = False
+        self._replay = None          # loaded telemetry.Replay
+        self._replay_playing = False
+        self._replay_frame = 0.0
+        self._replay_speed = 1.0
+        self._replay_after = None
+        self._replay_focus = None    # driver abbreviation the HUD follows
+        self._replay_resize_job = None
+        self._replay_last_size = (0, 0)
+        self._replay_car_items = {}
         # Telemetry font for the racing-console readouts.  Cascadia Mono
         # ships with Windows Terminal / Win10 1903+; Consolas is on every
         # Windows box; Courier New is the universal fallback.
@@ -1367,13 +1391,23 @@ class ApexAI:
                                            self._on_show_replays, num="05")
         self.btn_replays.pack(side=tk.LEFT, padx=(0, 6))
 
+        self.btn_telemetry = self._make_tab(ctrl, "TELEMETRY",
+                                             self._on_show_telemetry, num="06")
+        self.btn_telemetry.pack(side=tk.LEFT, padx=(0, 6))
+
+        self.btn_replay = self._make_tab(ctrl, "SESSION REPLAY",
+                                          self._on_show_replay, num="07")
+        self.btn_replay.pack(side=tk.LEFT, padx=(0, 6))
+
         # Trailing refresh button is visually quieter (icon-style ↻).
         self.btn_refresh = self._make_tab(ctrl, "↻ REFRESH",
                                            self._on_refresh, secondary=True)
         self.btn_refresh.pack(side=tk.LEFT, padx=(8, 0))
 
         self._all_btns = [self.btn_predict, self.btn_all, self.btn_viz,
-                          self.btn_radio, self.btn_replays, self.btn_refresh]
+                          self.btn_radio, self.btn_replays,
+                          self.btn_telemetry, self.btn_replay,
+                          self.btn_refresh]
 
         # ── Footer status bar (always visible, never truncated) ──
         # Packed at the BOTTOM of the window first so the body fills the
@@ -1418,6 +1452,12 @@ class ApexAI:
         self.replays_frame = tk.Frame(self.root, bg=BG, padx=36, pady=8)
         self._replays_built = False
         self._replays_year = None
+
+        # Telemetry comparison + data-driven session replay (hidden
+        # initially).  Both are lazily built on first open like the tabs
+        # above, so launch time is unaffected.
+        self.telemetry_frame = tk.Frame(self.root, bg=BG, padx=28, pady=8)
+        self.replay_frame = tk.Frame(self.root, bg=BG, padx=20, pady=6)
         self._radio_clips = []
         self._radio_clip_meta = []        # parallel: per-clip {lap, event, dt}
         self._radio_event_log = []        # raw f1radio event_log for the race
@@ -2369,10 +2409,16 @@ class ApexAI:
     def _switch_to_view(self, view):
         self._current_view = view
         self._anim_running = False
+        # Leaving the replay tab pauses playback rather than tearing it
+        # down, so coming back resumes exactly where you left off.
+        if view != "replay":
+            self._replay_pause()
         self.body.pack_forget()
         self.viz_frame.pack_forget()
         self.radio_frame.pack_forget()
         self.replays_frame.pack_forget()
+        self.telemetry_frame.pack_forget()
+        self.replay_frame.pack_forget()
         if view == "predictions":
             self.body.pack(fill=tk.BOTH, expand=True)
             self._set_active_btn(None)
@@ -2385,6 +2431,12 @@ class ApexAI:
         elif view == "replays":
             self.replays_frame.pack(fill=tk.BOTH, expand=True)
             self._set_active_btn(self.btn_replays)
+        elif view == "telemetry":
+            self.telemetry_frame.pack(fill=tk.BOTH, expand=True)
+            self._set_active_btn(self.btn_telemetry)
+        elif view == "replay":
+            self.replay_frame.pack(fill=tk.BOTH, expand=True)
+            self._set_active_btn(self.btn_replay)
 
     def _on_show_viz(self):
         if self._current_view == "viz":
@@ -3555,6 +3607,1474 @@ class ApexAI:
                 border=border,
             )
             btn.pack(side=tk.LEFT, padx=4)
+
+    # ══════════════════════════════════════════════════════════════════
+    # Telemetry & Session Replay
+    # ══════════════════════════════════════════════════════════════════
+    # Two data-driven views built on the FastF1 streams in telemetry.py:
+    #
+    #   06 TELEMETRY      – overlay any two laps on a shared distance axis.
+    #                       Because the alignment is by distance and not by
+    #                       clock, the two laps can come from different
+    #                       sessions or different seasons, which is what
+    #                       makes lap-vs-lap, compound-vs-compound and
+    #                       year-vs-year comparisons all the same feature.
+    #   07 SESSION REPLAY – scrub any session frame-by-frame with a live
+    #                       track map, a timing screen and a telemetry HUD.
+    #
+    # Both hang off the same season / round / session picker below.
+
+    # FastF1 only carries car + position telemetry from 2018 onwards; older
+    # seasons have results but nothing to plot or replay, so the season
+    # selector stops there rather than offering years that always fail.
+    TEL_FIRST_YEAR = 2018
+
+    # Playback rates offered by the replay transport.
+    REPLAY_SPEEDS = (0.5, 1, 2, 4, 8, 16)
+
+    # ── Shared season / round / session picker ──
+
+    def _tel_years(self):
+        return [str(y) for y in
+                range(datetime.now().year, self.TEL_FIRST_YEAR - 1, -1)]
+
+    def _picker(self, key):
+        return self._pickers.setdefault(key, {})
+
+    def _build_session_picker(self, parent, key, on_change=None,
+                              round_width=30):
+        """Season / Round / Session combo trio.
+
+        `key` namespaces the widget state on `self._pickers` so the
+        telemetry tab's two independent pickers and the replay tab's
+        picker can all coexist.  `on_change` fires whenever the selection
+        becomes complete (or changes), on the Tk thread.
+        """
+        st = self._picker(key)
+        st["on_change"] = on_change
+        st["rounds"] = {}
+        st["sessions"] = {}
+
+        row = tk.Frame(parent, bg=BG)
+        st["frame"] = row
+
+        tk.Label(row, text="SEASON", font=(self.MONO, 8), fg=MUTED,
+                 bg=BG).pack(side=tk.LEFT, padx=(0, 5))
+        st["year_var"] = tk.StringVar(value=str(datetime.now().year))
+        st["year_cb"] = ttk.Combobox(
+            row, values=self._tel_years(), state="readonly",
+            textvariable=st["year_var"], width=6,
+            font=("Helvetica Neue", 10))
+        st["year_cb"].pack(side=tk.LEFT, padx=(0, 12))
+        st["year_cb"].bind("<<ComboboxSelected>>",
+                           lambda _e, k=key: self._picker_load_rounds(k))
+
+        tk.Label(row, text="ROUND", font=(self.MONO, 8), fg=MUTED,
+                 bg=BG).pack(side=tk.LEFT, padx=(0, 5))
+        st["round_var"] = tk.StringVar(value="")
+        st["round_cb"] = ttk.Combobox(
+            row, values=[], state="readonly",
+            textvariable=st["round_var"], width=round_width,
+            font=("Helvetica Neue", 10))
+        st["round_cb"].pack(side=tk.LEFT, padx=(0, 12))
+        st["round_cb"].bind("<<ComboboxSelected>>",
+                            lambda _e, k=key: self._picker_load_sessions(k))
+
+        tk.Label(row, text="SESSION", font=(self.MONO, 8), fg=MUTED,
+                 bg=BG).pack(side=tk.LEFT, padx=(0, 5))
+        st["sess_var"] = tk.StringVar(value="")
+        st["sess_cb"] = ttk.Combobox(
+            row, values=[], state="readonly",
+            textvariable=st["sess_var"], width=17,
+            font=("Helvetica Neue", 10))
+        st["sess_cb"].pack(side=tk.LEFT)
+        st["sess_cb"].bind("<<ComboboxSelected>>",
+                           lambda _e, k=key: self._picker_notify(k))
+
+        self._picker_load_rounds(key)
+        return row
+
+    def _picker_set_enabled(self, key, enabled):
+        state = "readonly" if enabled else "disabled"
+        st = self._picker(key)
+        for name in ("year_cb", "round_cb", "sess_cb"):
+            cb = st.get(name)
+            if cb is not None:
+                try:
+                    cb.configure(state=state)
+                except tk.TclError:
+                    pass
+
+    def _picker_load_rounds(self, key):
+        """Populate the round list for the selected season, off-thread."""
+        st = self._picker(key)
+        try:
+            year = int(st["year_var"].get())
+        except (ValueError, KeyError):
+            return
+        st["round_cb"].configure(values=["Loading…"])
+        st["round_var"].set("Loading…")
+
+        def work():
+            try:
+                sched = get_event_schedule_cached(year)
+                rows = []
+                today = datetime.now().date()
+                for _, ev in sched.iterrows():
+                    rnd = int(ev["RoundNumber"])
+                    name = str(ev["EventName"])
+                    try:
+                        ev_date = ev["EventDate"].date()
+                    except Exception:
+                        ev_date = None
+                    future = ev_date is not None and ev_date > today
+                    label = f"{rnd:02d} · {name}"
+                    if future:
+                        label += "  (upcoming)"
+                    rows.append((label, rnd))
+                err = None
+            except Exception as exc:
+                rows, err = [], exc
+            self.root.after(0, lambda: self._picker_rounds_ready(
+                key, year, rows, err))
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _picker_rounds_ready(self, key, year, rows, err):
+        st = self._picker(key)
+        # The user may have moved on to another season while we were
+        # fetching; drop the stale result rather than clobbering their
+        # current selection.
+        try:
+            if int(st["year_var"].get()) != year:
+                return
+        except (ValueError, KeyError, tk.TclError):
+            return
+        if err or not rows:
+            st["round_cb"].configure(values=[])
+            st["round_var"].set("")
+            self._set_status(f"Could not load the {year} calendar: {err}"
+                             if err else f"No rounds found for {year}")
+            return
+        st["rounds"] = {label: rnd for label, rnd in rows}
+        labels = [label for label, _ in rows]
+        st["round_cb"].configure(values=labels)
+        # Default to the most recent round that has actually run — that's
+        # the one you almost always want to look at.
+        done = [lb for lb in labels if "(upcoming)" not in lb]
+        st["round_var"].set(done[-1] if done else labels[0])
+        self._picker_load_sessions(key)
+
+    def _picker_load_sessions(self, key):
+        st = self._picker(key)
+        rnd = st["rounds"].get(st["round_var"].get())
+        try:
+            year = int(st["year_var"].get())
+        except (ValueError, KeyError):
+            return
+        if rnd is None:
+            return
+        st["sess_cb"].configure(values=["Loading…"])
+        st["sess_var"].set("Loading…")
+
+        def work():
+            try:
+                avail = teldata.available_sessions(year, rnd)
+            except Exception:
+                avail = [("R", "Race"), ("Q", "Qualifying")]
+            self.root.after(0, lambda: self._picker_sessions_ready(
+                key, year, rnd, avail))
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _picker_sessions_ready(self, key, year, rnd, avail):
+        st = self._picker(key)
+        try:
+            if (int(st["year_var"].get()) != year
+                    or st["rounds"].get(st["round_var"].get()) != rnd):
+                return
+        except (ValueError, KeyError, tk.TclError):
+            return
+        st["sessions"] = {label: code for code, label in avail}
+        labels = [label for _, label in avail]
+        st["sess_cb"].configure(values=labels)
+        st["sess_var"].set(labels[0] if labels else "")
+        self._picker_notify(key)
+
+    def _picker_notify(self, key):
+        cb = self._picker(key).get("on_change")
+        if cb:
+            cb()
+
+    def _picker_selection(self, key):
+        """(year, round, session_code) or None if the picker isn't ready."""
+        st = self._picker(key)
+        try:
+            year = int(st["year_var"].get())
+        except (ValueError, KeyError, tk.TclError):
+            return None
+        rnd = st.get("rounds", {}).get(st["round_var"].get())
+        code = st.get("sessions", {}).get(st["sess_var"].get())
+        if rnd is None or code is None:
+            return None
+        return (year, rnd, code)
+
+    def _picker_copy(self, src, dst):
+        """Mirror one picker's selection onto another (LINK mode)."""
+        s, d = self._picker(src), self._picker(dst)
+        if not s.get("year_var") or not d.get("year_var"):
+            return
+        d["rounds"] = dict(s.get("rounds", {}))
+        d["sessions"] = dict(s.get("sessions", {}))
+        d["year_cb"].configure(values=s["year_cb"].cget("values"))
+        d["round_cb"].configure(values=s["round_cb"].cget("values"))
+        d["sess_cb"].configure(values=s["sess_cb"].cget("values"))
+        d["year_var"].set(s["year_var"].get())
+        d["round_var"].set(s["round_var"].get())
+        d["sess_var"].set(s["sess_var"].get())
+
+    # ── 06 · Telemetry comparison ──
+
+    def _on_show_telemetry(self):
+        if self._current_view == "telemetry":
+            self._switch_to_view("predictions")
+            return
+        if not HAS_TELEMETRY:
+            self._set_status("FastF1 is required for telemetry "
+                             "(pip install -r requirements.txt)")
+            return
+        if not self._telemetry_built:
+            self._build_telemetry()
+            self._telemetry_built = True
+        self._switch_to_view("telemetry")
+        self._set_status("Telemetry · pick two laps and hit COMPARE")
+
+    def _build_telemetry(self):
+        for w in self.telemetry_frame.winfo_children():
+            w.destroy()
+
+        top = tk.Frame(self.telemetry_frame, bg=BG)
+        top.pack(fill=tk.X, pady=(0, 6))
+        tk.Label(top, text="TELEMETRY", font=("Helvetica Neue", 16, "bold"),
+                 fg=GOLD, bg=BG).pack(side=tk.LEFT)
+        tk.Label(top, text="Overlay any two laps — lap vs lap, compound vs "
+                           "compound, year vs year",
+                 font=("Helvetica Neue", 11), fg=MUTED, bg=BG
+                 ).pack(side=tk.LEFT, padx=(16, 0), pady=(3, 0))
+
+        # LINK keeps side B on the same session as side A, which is the
+        # common case (two team-mates in one race).  Unlink it to reach
+        # across sessions and seasons.
+        self._tel_link = tk.BooleanVar(value=True)
+        link = tk.Checkbutton(
+            top, text="LINK SESSIONS", variable=self._tel_link,
+            command=self._tel_link_changed,
+            font=(self.MONO, 8), fg=GRAY, bg=BG, activebackground=BG,
+            activeforeground=WHITE, selectcolor=BG_SURFACE,
+            highlightthickness=0, bd=0, cursor="hand2",
+        )
+        link.pack(side=tk.RIGHT)
+
+        tk.Frame(self.telemetry_frame, bg=F1_RED, height=2).pack(
+            fill=tk.X, pady=(2, 8))
+
+        # -- two lap selectors --
+        self._tel_sides = {}
+        for side, accent in (("a", GOLD), ("b", "#4FA3FF")):
+            self._build_tel_side(self.telemetry_frame, side, accent)
+
+        # -- action row --
+        actions = tk.Frame(self.telemetry_frame, bg=BG)
+        actions.pack(fill=tk.X, pady=(8, 6))
+        self._tel_compare_btn = self._make_btn(
+            actions, "COMPARE LAPS", GOLD, WHITE, self._tel_compare,
+            border=GOLD_GLOW)
+        self._tel_compare_btn.pack(side=tk.LEFT)
+        self._make_btn(actions, "⇄ SWAP", BG_SURFACE, WHITE,
+                       self._tel_swap, border=BORDER).pack(
+            side=tk.LEFT, padx=(8, 0))
+        self._tel_status = tk.Label(
+            actions, text="", font=(self.MONO, 9), fg=MUTED, bg=BG)
+        self._tel_status.pack(side=tk.LEFT, padx=(16, 0))
+
+        # -- scrollable results --
+        body = tk.Frame(self.telemetry_frame, bg=BG)
+        body.pack(fill=tk.BOTH, expand=True)
+        self._tel_canvas = tk.Canvas(body, bg=BG, highlightthickness=0)
+        sb = ttk.Scrollbar(body, orient="vertical",
+                           command=self._tel_canvas.yview)
+        self._tel_inner = tk.Frame(self._tel_canvas, bg=BG)
+        self._tel_inner.bind(
+            "<Configure>",
+            lambda e: self._tel_canvas.configure(
+                scrollregion=self._tel_canvas.bbox("all")))
+        self._tel_canvas.create_window((0, 0), window=self._tel_inner,
+                                       anchor="nw")
+        self._tel_canvas.configure(yscrollcommand=sb.set)
+        sb.pack(side=tk.RIGHT, fill=tk.Y)
+        self._tel_canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        def _wheel(e, c=self._tel_canvas):
+            c.yview_scroll(self._wheel_units(e), "units")
+            return "break"
+
+        for w in (self._tel_canvas, self._tel_inner):
+            w.bind("<MouseWheel>", _wheel)
+        self._tel_wheel = _wheel
+
+        tk.Label(self._tel_inner,
+                 text="Choose a session, then a driver and lap on each side.\n"
+                      "Turn LINK SESSIONS off to compare across sessions or "
+                      "seasons.",
+                 font=("Helvetica Neue", 11), fg=MUTED, bg=BG,
+                 justify=tk.LEFT).pack(anchor="w", pady=24)
+
+        self._tel_link_changed()
+
+    def _build_tel_side(self, parent, side, accent):
+        """One row of the comparison picker: session + driver + lap."""
+        card = tk.Frame(parent, bg=BG_SURFACE,
+                        highlightbackground=BORDER, highlightthickness=1)
+        card.pack(fill=tk.X, pady=3)
+        inner = tk.Frame(card, bg=BG_SURFACE, padx=10, pady=7)
+        inner.pack(fill=tk.X)
+
+        tk.Frame(inner, bg=accent, width=4, height=26).pack(
+            side=tk.LEFT, padx=(0, 10), fill=tk.Y)
+        tk.Label(inner, text=f"CAR {side.upper()}",
+                 font=(self.MONO, 10, "bold"), fg=accent,
+                 bg=BG_SURFACE).pack(side=tk.LEFT, padx=(0, 14))
+
+        picker_host = tk.Frame(inner, bg=BG_SURFACE)
+        picker_host.pack(side=tk.LEFT)
+        # The picker paints itself on BG; re-parent onto the card colour so
+        # the row reads as a single module.
+        row = self._build_session_picker(
+            picker_host, f"tel_{side}",
+            on_change=lambda s=side: self._tel_session_changed(s),
+            round_width=26)
+        for w in [row] + list(row.winfo_children()):
+            try:
+                if isinstance(w, (tk.Frame, tk.Label)):
+                    w.configure(bg=BG_SURFACE)
+            except tk.TclError:
+                pass
+        row.pack(side=tk.LEFT)
+
+        st = self._picker(f"tel_{side}")
+        tk.Label(inner, text="DRIVER", font=(self.MONO, 8), fg=MUTED,
+                 bg=BG_SURFACE).pack(side=tk.LEFT, padx=(14, 5))
+        st["driver_var"] = tk.StringVar(value="")
+        st["driver_cb"] = ttk.Combobox(
+            inner, values=[], state="readonly", width=6,
+            textvariable=st["driver_var"], font=("Helvetica Neue", 10))
+        st["driver_cb"].pack(side=tk.LEFT)
+        st["driver_cb"].bind(
+            "<<ComboboxSelected>>",
+            lambda _e, s=side: self._tel_driver_changed(s))
+
+        tk.Label(inner, text="LAP", font=(self.MONO, 8), fg=MUTED,
+                 bg=BG_SURFACE).pack(side=tk.LEFT, padx=(12, 5))
+        st["lap_var"] = tk.StringVar(value="")
+        st["lap_cb"] = ttk.Combobox(
+            inner, values=[], state="readonly", width=22,
+            textvariable=st["lap_var"], font=(self.MONO, 9))
+        st["lap_cb"].pack(side=tk.LEFT)
+
+        self._tel_sides[side] = {"card": card, "accent": accent}
+
+    def _tel_link_changed(self):
+        """LINK on: side B follows side A's session and its combos lock."""
+        linked = bool(self._tel_link.get())
+        self._picker_set_enabled("tel_b", not linked)
+        if linked:
+            self._picker_copy("tel_a", "tel_b")
+            self._tel_session_changed("b")
+
+    def _tel_session_changed(self, side):
+        """Session selection changed — reload that side's driver list."""
+        if side == "a" and bool(self._tel_link.get()):
+            self._picker_copy("tel_a", "tel_b")
+            self.root.after(0, lambda: self._tel_load_drivers("b"))
+        self._tel_load_drivers(side)
+
+    def _tel_load_drivers(self, side):
+        key = f"tel_{side}"
+        sel = self._picker_selection(key)
+        if sel is None:
+            return
+        year, rnd, code = sel
+        st = self._picker(key)
+        st["driver_cb"].configure(values=[])
+        st["driver_var"].set("")
+        st["lap_cb"].configure(values=[])
+        st["lap_var"].set("")
+        self._tel_say(f"Loading {code} · {year} round {rnd}…")
+
+        def work():
+            try:
+                session = teldata.load_session(
+                    year, rnd, code, with_telemetry=False,
+                    progress=lambda m: self.root.after(
+                        0, lambda mm=m: self._tel_say(mm)))
+                drivers = teldata.driver_table(session, TEAM_COLORS)
+                err = None
+            except Exception as exc:
+                session, drivers, err = None, [], exc
+            self.root.after(0, lambda: self._tel_drivers_ready(
+                side, year, rnd, code, session, drivers, err))
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _tel_drivers_ready(self, side, year, rnd, code, session, drivers, err):
+        key = f"tel_{side}"
+        if self._picker_selection(key) != (year, rnd, code):
+            return  # selection moved on while we were loading
+        st = self._picker(key)
+        if err or not drivers:
+            self._tel_say(str(err) if err
+                          else "That session loaded, but lists no drivers.")
+            return
+        st["session"] = session
+        st["driver_info"] = {d.abbr: d for d in drivers}
+        st["driver_cb"].configure(values=[d.abbr for d in drivers])
+        st["driver_var"].set(drivers[0].abbr)
+        self._tel_driver_changed(side)
+        self._tel_say(f"{len(drivers)} drivers loaded · "
+                      f"{teldata.session_display_name(session)}")
+
+    def _tel_driver_changed(self, side):
+        key = f"tel_{side}"
+        st = self._picker(key)
+        session = st.get("session")
+        abbr = st["driver_var"].get()
+        if session is None or not abbr:
+            return
+        laps = teldata.lap_table(session, abbr)
+        st["laps"] = {lap.label: lap.number for lap in laps}
+        fastest = teldata.fastest_lap_number(session, abbr)
+        labels = ["Fastest lap"] + [lap.label for lap in laps]
+        st["lap_cb"].configure(values=labels)
+        # Default both sides to the fastest lap — the comparison people
+        # reach for first.
+        st["lap_var"].set("Fastest lap")
+        st["fastest"] = fastest
+
+    def _tel_say(self, msg):
+        try:
+            self._tel_status.configure(text=msg)
+        except (AttributeError, tk.TclError):
+            pass
+
+    def _tel_swap(self):
+        """Swap the two sides so the delta flips reference."""
+        if bool(self._tel_link.get()):
+            a, b = self._picker("tel_a"), self._picker("tel_b")
+            for field in ("driver_var", "lap_var"):
+                av, bv = a[field].get(), b[field].get()
+                a[field].set(bv)
+                b[field].set(av)
+            # Lap lists are per-driver, so rebuild both after the swap.
+            for side in ("a", "b"):
+                st = self._picker(f"tel_{side}")
+                keep = st["lap_var"].get()
+                self._tel_driver_changed(side)
+                if keep in st["lap_cb"].cget("values"):
+                    st["lap_var"].set(keep)
+            self._tel_compare()
+        else:
+            self._tel_say("Turn LINK SESSIONS on to swap, or re-pick "
+                          "each side manually")
+
+    def _tel_selected_lap(self, side):
+        """(year, round, code, driver, lap_number_or_None) for one side."""
+        key = f"tel_{side}"
+        sel = self._picker_selection(key)
+        st = self._picker(key)
+        abbr = st.get("driver_var").get() if st.get("driver_var") else ""
+        if sel is None or not abbr:
+            return None
+        label = st["lap_var"].get()
+        lap_no = None if label in ("", "Fastest lap") else \
+            st.get("laps", {}).get(label)
+        return (*sel, abbr, lap_no)
+
+    def _tel_compare(self):
+        a = self._tel_selected_lap("a")
+        b = self._tel_selected_lap("b")
+        if a is None or b is None:
+            self._tel_say("Pick a driver on both sides first")
+            return
+        if a == b:
+            self._tel_say("Both sides are the same lap — pick a different "
+                          "driver or lap on one side")
+            return
+
+        self._tel_say("Loading telemetry…")
+        self._set_busy(True)
+
+        def work():
+            try:
+                laps = []
+                for spec in (a, b):
+                    year, rnd, code, abbr, lap_no = spec
+                    session = teldata.load_session(
+                        year, rnd, code, with_telemetry=True,
+                        progress=lambda m: self.root.after(
+                            0, lambda mm=m: self._tel_say(mm)))
+                    laps.append(teldata.lap_telemetry(
+                        session, abbr, lap_no, TEAM_COLORS))
+                comparison = teldata.compare_laps(laps[0], laps[1])
+                err = None
+            except Exception as exc:
+                comparison, err = None, exc
+            self.root.after(
+                0, lambda: self._tel_compare_ready(comparison, err))
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _tel_compare_ready(self, comparison, err):
+        self._set_busy(False)
+        if err or comparison is None:
+            self._tel_say(f"Could not build the comparison: {err}")
+            self._set_status(f"Telemetry error: {err}")
+            return
+        self._tel_say("")
+        self._render_telemetry(comparison)
+        ref, oth = comparison.ref, comparison.other
+        self._set_status(
+            f"Telemetry · {ref.short_label} vs {oth.short_label} · "
+            f"{teldata.fmt_delta(comparison.final_delta)}s")
+
+    # ── Telemetry rendering ──
+
+    @staticmethod
+    def _tel_pair_colors(comparison):
+        """Colours for the two traces.
+
+        Team-mates share a livery colour, so if the two are too close to
+        tell apart we keep the reference on the team colour and shift the
+        comparison car onto a light tint of it.
+        """
+        c_a = comparison.ref.color or GOLD
+        c_b = comparison.other.color or "#4FA3FF"
+        if c_a.lower() == c_b.lower():
+            c_b = ApexAI._lighten(c_a, 70)
+        return c_a, c_b
+
+    def _tel_fig_width_in(self, dpi=100):
+        try:
+            w = self.telemetry_frame.winfo_width()
+        except tk.TclError:
+            w = 0
+        if w < 400:
+            w = 1040
+        return max(6.5, (w - 40) / dpi)
+
+    def _render_telemetry(self, comparison):
+        for w in self._tel_inner.winfo_children():
+            w.destroy()
+
+        self._render_tel_summary(self._tel_inner, comparison)
+
+        if not comparison.same_circuit:
+            warn = tk.Frame(self._tel_inner, bg="#3A2410",
+                            highlightbackground="#8A5A20",
+                            highlightthickness=1)
+            warn.pack(fill=tk.X, pady=(8, 0))
+            tk.Label(warn,
+                     text="⚠  These laps look like different circuits — the "
+                          "distance axis lines up by length only, so read "
+                          "the delta with care.",
+                     font=("Helvetica Neue", 10), fg="#F0C070", bg="#3A2410",
+                     padx=12, pady=7, justify=tk.LEFT,
+                     wraplength=900).pack(anchor="w")
+
+        for builder in (self._tel_traces_image, self._tel_dominance_image):
+            photo = builder(comparison)
+            if photo is None:
+                continue
+            lbl = tk.Label(self._tel_inner, image=photo, bg=BG, bd=0)
+            lbl.image = photo
+            lbl.pack(anchor="w", pady=(10, 0))
+            lbl.bind("<MouseWheel>", self._tel_wheel)
+
+        self._tel_canvas.yview_moveto(0)
+
+    def _render_tel_summary(self, parent, comparison):
+        """Two lap cards side by side plus the headline delta."""
+        row = tk.Frame(parent, bg=BG)
+        row.pack(fill=tk.X, pady=(8, 0))
+        c_a, c_b = self._tel_pair_colors(comparison)
+
+        for lap, color in ((comparison.ref, c_a), (comparison.other, c_b)):
+            card = tk.Frame(row, bg=BG_CARD, highlightbackground=BORDER,
+                            highlightthickness=1)
+            card.pack(side=tk.LEFT, padx=(0, 10))
+            inner = tk.Frame(card, bg=BG_CARD, padx=14, pady=10)
+            inner.pack()
+
+            head = tk.Frame(inner, bg=BG_CARD)
+            head.pack(anchor="w")
+            tk.Frame(head, bg=color, width=5, height=20).pack(
+                side=tk.LEFT, padx=(0, 8), fill=tk.Y)
+            tk.Label(head, text=lap.driver,
+                     font=("Helvetica Neue", 17, "bold"),
+                     fg=WHITE, bg=BG_CARD).pack(side=tk.LEFT)
+            tk.Label(head, text=teldata.fmt_laptime(lap.lap_time),
+                     font=(self.MONO, 15, "bold"), fg=color,
+                     bg=BG_CARD).pack(side=tk.LEFT, padx=(12, 0))
+
+            tk.Label(inner,
+                     text=f"{lap.year} {lap.event} · {lap.session_name} · "
+                          f"Lap {lap.lap_number}",
+                     font=("Helvetica Neue", 10), fg=GRAY,
+                     bg=BG_CARD).pack(anchor="w", pady=(3, 0))
+
+            stats = tk.Frame(inner, bg=BG_CARD)
+            stats.pack(anchor="w", pady=(7, 0))
+            tyre = (lap.compound or "—").title()
+            if lap.tyre_life:
+                tyre += f" · {int(lap.tyre_life)} laps"
+            for label, value, tint in (
+                ("TYRE", tyre, teldata.compound_color(lap.compound)),
+                ("TOP", f"{lap.top_speed:.0f} km/h", None),
+                ("AVG", f"{lap.avg_speed:.0f} km/h", None),
+                ("WOT", f"{lap.wot_pct:.0f}%", None),
+                ("BRAKE", f"{lap.braking_pct:.0f}%", None),
+            ):
+                cell = tk.Frame(stats, bg=BG_CARD)
+                cell.pack(side=tk.LEFT, padx=(0, 16))
+                tk.Label(cell, text=label, font=(self.MONO, 7), fg=MUTED,
+                         bg=BG_CARD).pack(anchor="w")
+                tk.Label(cell, text=value, font=(self.MONO, 10, "bold"),
+                         fg=tint or WHITE, bg=BG_CARD).pack(anchor="w")
+
+        # Headline delta card.
+        delta = comparison.final_delta
+        faster = comparison.ref if (delta or 0) > 0 else comparison.other
+        d_card = tk.Frame(row, bg=BG_CARD, highlightbackground=GOLD,
+                          highlightthickness=1)
+        d_card.pack(side=tk.LEFT)
+        d_in = tk.Frame(d_card, bg=BG_CARD, padx=16, pady=10)
+        d_in.pack()
+        tk.Label(d_in, text="LAP DELTA", font=(self.MONO, 7), fg=MUTED,
+                 bg=BG_CARD).pack(anchor="w")
+        tk.Label(d_in, text=f"{teldata.fmt_delta(delta)}s",
+                 font=(self.MONO, 20, "bold"), fg=GOLD,
+                 bg=BG_CARD).pack(anchor="w")
+        tk.Label(d_in, text=f"{faster.driver} faster",
+                 font=("Helvetica Neue", 10), fg=GRAY,
+                 bg=BG_CARD).pack(anchor="w")
+
+    def _tel_style_axis(self, ax, ylabel, last=False):
+        ax.set_facecolor(BG_CARD)
+        ax.grid(True, color=BORDER, linewidth=0.5, alpha=0.55)
+        ax.set_axisbelow(True)
+        for side in ("top", "right"):
+            ax.spines[side].set_visible(False)
+        for side in ("left", "bottom"):
+            ax.spines[side].set_color(BORDER)
+        ax.tick_params(colors=GRAY, labelsize=7.5)
+        ax.set_ylabel(ylabel, color=GRAY, fontsize=8)
+        if not last:
+            ax.tick_params(labelbottom=False)
+        else:
+            ax.set_xlabel("Distance around the lap (m)", color=GRAY,
+                          fontsize=8.5)
+
+    def _tel_traces_image(self, cmp_):
+        """Speed / delta / throttle / brake+DRS / gear, on a shared axis."""
+        if not HAS_PIL:
+            return None
+        ref, oth = cmp_.ref, cmp_.other
+        c_a, c_b = self._tel_pair_colors(cmp_)
+        dpi = 100
+        w_in = self._tel_fig_width_in(dpi)
+
+        fig = plt.figure(figsize=(w_in, 6.6), facecolor=BG, dpi=dpi)
+        gs = fig.add_gridspec(5, 1, height_ratios=[3.0, 1.7, 1.3, 1.0, 1.2],
+                              hspace=0.14, left=0.065, right=0.985,
+                              top=0.965, bottom=0.075)
+        ax_speed, ax_delta, ax_thr, ax_brk, ax_gear = [
+            fig.add_subplot(gs[i]) for i in range(5)]
+
+        # -- speed --
+        ax_speed.plot(ref.distance, ref.speed, color=c_a, linewidth=1.5,
+                      label=f"{ref.driver}  {teldata.fmt_laptime(ref.lap_time)}")
+        ax_speed.plot(oth.distance, oth.speed, color=c_b, linewidth=1.5,
+                      linestyle="--",
+                      label=f"{oth.driver}  {teldata.fmt_laptime(oth.lap_time)}")
+        self._tel_style_axis(ax_speed, "Speed (km/h)")
+        leg = ax_speed.legend(loc="lower right", fontsize=8, framealpha=0.9,
+                              facecolor=BG_SURFACE, edgecolor=BORDER)
+        for text in leg.get_texts():
+            text.set_color(WHITE)
+
+        # -- delta: positive means the comparison car is losing time --
+        self._tel_style_axis(ax_delta, f"Δ to {ref.driver} (s)")
+        ax_delta.axhline(0, color=GRAY, linewidth=0.8, alpha=0.7)
+        ax_delta.plot(cmp_.distance, cmp_.delta, color=WHITE, linewidth=1.2)
+        ax_delta.fill_between(cmp_.distance, 0, cmp_.delta,
+                              where=cmp_.delta >= 0, color=c_a, alpha=0.35,
+                              interpolate=True)
+        ax_delta.fill_between(cmp_.distance, 0, cmp_.delta,
+                              where=cmp_.delta < 0, color=c_b, alpha=0.35,
+                              interpolate=True)
+
+        # -- throttle --
+        ax_thr.plot(ref.distance, ref.throttle, color=c_a, linewidth=1.1)
+        ax_thr.plot(oth.distance, oth.throttle, color=c_b, linewidth=1.1,
+                    linestyle="--")
+        ax_thr.set_ylim(-5, 105)
+        self._tel_style_axis(ax_thr, "Throttle %")
+
+        # -- brake + DRS: both are on/off, so draw them as bands rather
+        #    than lines.  DRS codes 10/12/14 mean the flap is open. --
+        self._tel_style_axis(ax_brk, "Brake · DRS")
+        ax_brk.set_ylim(0, 2)
+        ax_brk.set_yticks([0.5, 1.5])
+        ax_brk.set_yticklabels([oth.driver, ref.driver], fontsize=7.5)
+        for idx, (lap, color) in enumerate(((oth, c_b), (ref, c_a))):
+            base = idx
+            ax_brk.fill_between(lap.distance, base + 0.05, base + 0.45,
+                                where=lap.brake > 0.5, color=color,
+                                step="mid", linewidth=0)
+            ax_brk.fill_between(lap.distance, base + 0.55, base + 0.95,
+                                where=lap.drs >= 10, color=GREEN,
+                                step="mid", linewidth=0, alpha=0.85)
+        ax_brk.text(0.995, 0.5, "brake ▁  DRS ▔", transform=ax_brk.transAxes,
+                    ha="right", va="center", fontsize=7, color=MUTED)
+
+        # -- gear --
+        ax_gear.step(ref.distance, ref.gear, where="mid", color=c_a,
+                     linewidth=1.1)
+        ax_gear.step(oth.distance, oth.gear, where="mid", color=c_b,
+                     linewidth=1.1, linestyle="--")
+        ax_gear.set_ylim(0.5, 8.8)
+        ax_gear.set_yticks(range(1, 9))
+        self._tel_style_axis(ax_gear, "Gear", last=True)
+
+        return self._fig_to_photo(fig)
+
+    def _tel_dominance_image(self, cmp_):
+        """Track map coloured by who owns each mini-sector, plus the
+        per-sector time swing that produced the final delta."""
+        if not HAS_PIL:
+            return None
+        ref, oth = cmp_.ref, cmp_.other
+        c_a, c_b = self._tel_pair_colors(cmp_)
+        dpi = 100
+        w_in = self._tel_fig_width_in(dpi)
+
+        fig = plt.figure(figsize=(w_in, 3.1), facecolor=BG, dpi=dpi)
+        gs = fig.add_gridspec(1, 2, width_ratios=[1.05, 1.6], wspace=0.14,
+                              left=0.02, right=0.985, top=0.88, bottom=0.16)
+        ax_map = fig.add_subplot(gs[0])
+        ax_bar = fig.add_subplot(gs[1])
+
+        # -- dominance map --
+        ax_map.set_facecolor(BG)
+        ax_map.set_xticks([])
+        ax_map.set_yticks([])
+        for s in ax_map.spines.values():
+            s.set_visible(False)
+        ax_map.set_title(f"Mini-sector dominance · {ref.driver} vs {oth.driver}",
+                         color=WHITE, fontsize=9, pad=6)
+
+        xs = np.interp(cmp_.distance, ref.distance, ref.x)
+        ys = np.interp(cmp_.distance, ref.distance, ref.y)
+        if np.isfinite(xs).any() and np.isfinite(ys).any():
+            edges = cmp_.minisector_edges
+            for i, winner in enumerate(cmp_.minisector_winner):
+                m = ((cmp_.distance >= edges[i])
+                     & (cmp_.distance <= edges[i + 1]))
+                if m.sum() < 2:
+                    continue
+                ax_map.plot(xs[m], ys[m],
+                            color=c_a if winner == 0 else c_b,
+                            linewidth=5, solid_capstyle="round")
+            ax_map.set_aspect("equal", adjustable="datalim")
+        else:
+            ax_map.text(0.5, 0.5, "No position data for this lap",
+                        transform=ax_map.transAxes, ha="center",
+                        va="center", color=MUTED, fontsize=9)
+
+        # -- per-sector swing --
+        ax_bar.set_facecolor(BG_CARD)
+        n = len(cmp_.minisector_delta)
+        colors = [c_a if d > 0 else c_b for d in cmp_.minisector_delta]
+        ax_bar.bar(range(1, n + 1), cmp_.minisector_delta, color=colors,
+                   width=0.78, edgecolor="none")
+        ax_bar.axhline(0, color=GRAY, linewidth=0.8, alpha=0.7)
+        ax_bar.grid(True, axis="y", color=BORDER, linewidth=0.5, alpha=0.55)
+        ax_bar.set_axisbelow(True)
+        for side in ("top", "right"):
+            ax_bar.spines[side].set_visible(False)
+        for side in ("left", "bottom"):
+            ax_bar.spines[side].set_color(BORDER)
+        ax_bar.tick_params(colors=GRAY, labelsize=7.5)
+        ax_bar.set_xlabel("Mini-sector", color=GRAY, fontsize=8.5)
+        ax_bar.set_ylabel("Time gained / lost (s)", color=GRAY, fontsize=8)
+        won_a = int((cmp_.minisector_winner == 0).sum())
+        ax_bar.set_title(
+            f"{ref.driver} quicker in {won_a} of {n} mini-sectors    ·    "
+            f"{oth.driver} in {n - won_a}",
+            color=WHITE, fontsize=9, pad=6)
+
+        return self._fig_to_photo(fig)
+
+    @staticmethod
+    def _fig_to_photo(fig):
+        """Render a matplotlib figure into a Tk image and free the figure."""
+        buf = io.BytesIO()
+        try:
+            fig.savefig(buf, format="png", facecolor=fig.get_facecolor(),
+                        dpi=fig.dpi)
+        finally:
+            plt.close(fig)
+        buf.seek(0)
+        return ImageTk.PhotoImage(Image.open(buf).convert("RGB"))
+
+    # ── 07 · Session replay ──
+
+    def _on_show_replay(self):
+        if self._current_view == "replay":
+            self._switch_to_view("predictions")
+            return
+        if not HAS_TELEMETRY:
+            self._set_status("FastF1 is required for session replay "
+                             "(pip install -r requirements.txt)")
+            return
+        if not self._replay_built:
+            self._build_replay_view()
+            self._replay_built = True
+        self._switch_to_view("replay")
+        if self._replay is None:
+            self._set_status("Session Replay · pick a session and hit LOAD")
+
+    def _build_replay_view(self):
+        for w in self.replay_frame.winfo_children():
+            w.destroy()
+
+        top = tk.Frame(self.replay_frame, bg=BG)
+        top.pack(fill=tk.X, pady=(0, 6))
+        tk.Label(top, text="SESSION REPLAY",
+                 font=("Helvetica Neue", 16, "bold"),
+                 fg=GOLD, bg=BG).pack(side=tk.LEFT)
+        tk.Label(top, text="Replay any session — live track map, timing "
+                           "screen and telemetry",
+                 font=("Helvetica Neue", 11), fg=MUTED, bg=BG
+                 ).pack(side=tk.LEFT, padx=(14, 0), pady=(3, 0))
+
+        picker_row = tk.Frame(self.replay_frame, bg=BG)
+        picker_row.pack(fill=tk.X, pady=(4, 0))
+        self._build_session_picker(picker_row, "replay").pack(side=tk.LEFT)
+        self._replay_load_btn = self._make_btn(
+            picker_row, "LOAD REPLAY", GOLD, WHITE, self._replay_load,
+            border=GOLD_GLOW)
+        self._replay_load_btn.pack(side=tk.LEFT, padx=(14, 0))
+        self._replay_status = tk.Label(
+            picker_row, text="", font=(self.MONO, 9), fg=MUTED, bg=BG)
+        self._replay_status.pack(side=tk.LEFT, padx=(14, 0))
+
+        tk.Frame(self.replay_frame, bg=F1_RED, height=2).pack(
+            fill=tk.X, pady=(8, 8))
+
+        # -- transport sits at the bottom so the stage above can expand --
+        self._build_replay_transport(self.replay_frame)
+
+        stage = tk.Frame(self.replay_frame, bg=BG)
+        stage.pack(fill=tk.BOTH, expand=True)
+
+        self.replay_canvas = tk.Canvas(stage, bg="#0E0E14",
+                                       highlightthickness=1,
+                                       highlightbackground=BORDER, bd=0)
+        self.replay_canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.replay_canvas.bind("<Configure>", self._replay_canvas_resized)
+
+        side = tk.Frame(stage, bg=BG, width=330)
+        side.pack(side=tk.RIGHT, fill=tk.Y, padx=(10, 0))
+        side.pack_propagate(False)
+        self._build_replay_timing(side)
+        self._build_replay_hud(side)
+
+    def _build_replay_transport(self, parent):
+        bar = tk.Frame(parent, bg=BG_SURFACE, highlightbackground=BORDER,
+                       highlightthickness=1)
+        bar.pack(side=tk.BOTTOM, fill=tk.X, pady=(8, 0))
+        inner = tk.Frame(bar, bg=BG_SURFACE, padx=10, pady=7)
+        inner.pack(fill=tk.X)
+
+        self._replay_play_btn = self._make_btn(
+            inner, "▶  PLAY", GOLD, WHITE, self._replay_toggle_play,
+            border=GOLD_GLOW)
+        self._replay_play_btn.pack(side=tk.LEFT)
+
+        for label, cmd in (("⏮", lambda: self._replay_seek_frame(0)),
+                           ("−1 LAP", lambda: self._replay_step_lap(-1)),
+                           ("+1 LAP", lambda: self._replay_step_lap(1)),
+                           ("⏭", self._replay_seek_end)):
+            self._make_btn(inner, label, BG_HOVER, WHITE, cmd,
+                           border=BORDER).pack(side=tk.LEFT, padx=(6, 0))
+
+        tk.Label(inner, text="SPEED", font=(self.MONO, 8), fg=MUTED,
+                 bg=BG_SURFACE).pack(side=tk.LEFT, padx=(16, 6))
+        self._replay_speed_btns = {}
+        for mult in self.REPLAY_SPEEDS:
+            label = f"{mult:g}×"
+            btn = self._make_btn(
+                inner, label, BG_HOVER, GRAY,
+                lambda m=mult: self._replay_set_speed(m), border=BORDER)
+            btn.pack(side=tk.LEFT, padx=2)
+            self._replay_speed_btns[mult] = btn
+
+        # Clock + lap counter on the right of the transport.
+        self._replay_clock = tk.Label(
+            inner, text="--:--:--", font=(self.MONO, 12, "bold"),
+            fg=WHITE, bg=BG_SURFACE)
+        self._replay_clock.pack(side=tk.RIGHT, padx=(10, 0))
+        self._replay_lap_lbl = tk.Label(
+            inner, text="LAP —", font=(self.MONO, 12, "bold"),
+            fg=GOLD, bg=BG_SURFACE)
+        self._replay_lap_lbl.pack(side=tk.RIGHT, padx=(10, 0))
+
+        scrub_row = tk.Frame(bar, bg=BG_SURFACE)
+        scrub_row.pack(fill=tk.X, padx=10, pady=(0, 7))
+        self._replay_scrub_var = tk.DoubleVar(value=0.0)
+        self._replay_scrub = ttk.Scale(
+            scrub_row, from_=0, to=1, orient="horizontal",
+            variable=self._replay_scrub_var, command=self._replay_scrubbed)
+        self._replay_scrub.pack(fill=tk.X)
+        self._replay_scrub_guard = False
+
+        self._replay_set_speed(1)
+
+    def _build_replay_timing(self, parent):
+        head = tk.Frame(parent, bg=BG)
+        head.pack(fill=tk.X)
+        tk.Label(head, text="LIVE TIMING", font=(self.MONO, 9, "bold"),
+                 fg=GOLD, bg=BG).pack(side=tk.LEFT)
+        self._replay_order_note = tk.Label(
+            head, text="", font=(self.MONO, 7), fg=MUTED, bg=BG)
+        self._replay_order_note.pack(side=tk.RIGHT)
+
+        wrap = tk.Frame(parent, bg=BG_SURFACE, highlightbackground=BORDER,
+                        highlightthickness=1)
+        wrap.pack(fill=tk.BOTH, expand=True, pady=(4, 8))
+
+        hdr = tk.Frame(wrap, bg=BG_CARD)
+        hdr.pack(fill=tk.X)
+        for text, width, anchor in (("P", 3, "w"), ("DRIVER", 6, "w"),
+                                    ("LAP", 4, "e"), ("GAP", 9, "e"),
+                                    ("BEST", 9, "e")):
+            tk.Label(hdr, text=text, font=(self.MONO, 7), fg=MUTED,
+                     bg=BG_CARD, width=width, anchor=anchor).pack(
+                side=tk.LEFT, padx=1, pady=2)
+
+        # Pre-build a fixed pool of rows and update their text each frame;
+        # destroying and re-creating twenty rows at 25 fps would thrash Tk.
+        self._replay_rows = []
+        rows_host = tk.Frame(wrap, bg=BG_SURFACE)
+        rows_host.pack(fill=tk.BOTH, expand=True)
+        for i in range(24):
+            row = tk.Frame(rows_host, bg=BG_SURFACE, cursor="hand2")
+            cells = {}
+            cells["accent"] = tk.Frame(row, bg=BG_SURFACE, width=3)
+            cells["accent"].pack(side=tk.LEFT, fill=tk.Y)
+            for name, width, anchor, font, color in (
+                ("pos", 3, "w", (self.MONO, 9, "bold"), GRAY),
+                ("abbr", 6, "w", (self.MONO, 9, "bold"), WHITE),
+                ("lap", 4, "e", (self.MONO, 8), GRAY),
+                ("gap", 9, "e", (self.MONO, 8), WHITE),
+                ("best", 9, "e", (self.MONO, 8), GRAY),
+            ):
+                lbl = tk.Label(row, text="", font=font, fg=color,
+                               bg=BG_SURFACE, width=width, anchor=anchor)
+                lbl.pack(side=tk.LEFT, padx=1)
+                cells[name] = lbl
+            cells["tyre"] = tk.Label(row, text="", font=(self.MONO, 8, "bold"),
+                                     fg=MUTED, bg=BG_SURFACE, width=2)
+            cells["tyre"].pack(side=tk.LEFT)
+            row._cells = cells
+            row._abbr = None
+            # Clicking a row moves the HUD onto that driver.
+            for w in [row] + list(row.winfo_children()):
+                w.bind("<Button-1>",
+                       lambda _e, r=row: self._replay_focus_row(r))
+            self._replay_rows.append(row)
+
+    def _build_replay_hud(self, parent):
+        tk.Label(parent, text="TELEMETRY", font=(self.MONO, 9, "bold"),
+                 fg=GOLD, bg=BG).pack(anchor="w")
+        wrap = tk.Frame(parent, bg=BG_SURFACE, highlightbackground=BORDER,
+                        highlightthickness=1)
+        wrap.pack(fill=tk.X, pady=(4, 0))
+        inner = tk.Frame(wrap, bg=BG_SURFACE, padx=10, pady=8)
+        inner.pack(fill=tk.X)
+
+        head = tk.Frame(inner, bg=BG_SURFACE)
+        head.pack(fill=tk.X)
+        self._hud_accent = tk.Frame(head, bg=GOLD, width=5, height=22)
+        self._hud_accent.pack(side=tk.LEFT, padx=(0, 8), fill=tk.Y)
+        self._hud_driver = tk.Label(head, text="—",
+                                    font=("Helvetica Neue", 15, "bold"),
+                                    fg=WHITE, bg=BG_SURFACE)
+        self._hud_driver.pack(side=tk.LEFT)
+        self._hud_team = tk.Label(head, text="", font=(self.MONO, 8),
+                                  fg=MUTED, bg=BG_SURFACE)
+        self._hud_team.pack(side=tk.LEFT, padx=(8, 0), pady=(4, 0))
+
+        speed_row = tk.Frame(inner, bg=BG_SURFACE)
+        speed_row.pack(fill=tk.X, pady=(6, 2))
+        self._hud_speed = tk.Label(speed_row, text="—",
+                                   font=(self.MONO, 26, "bold"),
+                                   fg=WHITE, bg=BG_SURFACE)
+        self._hud_speed.pack(side=tk.LEFT)
+        tk.Label(speed_row, text="km/h", font=(self.MONO, 8), fg=MUTED,
+                 bg=BG_SURFACE).pack(side=tk.LEFT, padx=(4, 0), pady=(12, 0))
+        self._hud_gear = tk.Label(speed_row, text="—",
+                                  font=(self.MONO, 22, "bold"),
+                                  fg=GOLD, bg=BG_SURFACE)
+        self._hud_gear.pack(side=tk.RIGHT)
+        tk.Label(speed_row, text="GEAR", font=(self.MONO, 7), fg=MUTED,
+                 bg=BG_SURFACE).pack(side=tk.RIGHT, padx=(0, 5), pady=(10, 0))
+
+        # Throttle / brake bars: a pit-wall pedal trace in two rows.
+        self._hud_bars = {}
+        for name, color in (("throttle", GREEN), ("brake", F1_RED)):
+            bar_row = tk.Frame(inner, bg=BG_SURFACE)
+            bar_row.pack(fill=tk.X, pady=1)
+            tk.Label(bar_row, text=name.upper()[:4], font=(self.MONO, 7),
+                     fg=MUTED, bg=BG_SURFACE, width=5,
+                     anchor="w").pack(side=tk.LEFT)
+            cv = tk.Canvas(bar_row, height=10, bg=BG_CARD,
+                           highlightthickness=0, bd=0)
+            cv.pack(side=tk.LEFT, fill=tk.X, expand=True)
+            rect = cv.create_rectangle(0, 0, 0, 10, fill=color, outline="")
+            self._hud_bars[name] = (cv, rect)
+
+        foot = tk.Frame(inner, bg=BG_SURFACE)
+        foot.pack(fill=tk.X, pady=(6, 0))
+        self._hud_chips = {}
+        for name, label in (("rpm", "RPM"), ("drs", "DRS"),
+                            ("tyre", "TYRE"), ("lap", "LAP")):
+            cell = tk.Frame(foot, bg=BG_SURFACE)
+            cell.pack(side=tk.LEFT, padx=(0, 14))
+            tk.Label(cell, text=label, font=(self.MONO, 7), fg=MUTED,
+                     bg=BG_SURFACE).pack(anchor="w")
+            val = tk.Label(cell, text="—", font=(self.MONO, 10, "bold"),
+                           fg=WHITE, bg=BG_SURFACE)
+            val.pack(anchor="w")
+            self._hud_chips[name] = val
+
+    # ── Replay loading ──
+
+    def _replay_say(self, msg):
+        try:
+            self._replay_status.configure(text=msg)
+        except (AttributeError, tk.TclError):
+            pass
+
+    def _replay_load(self):
+        sel = self._picker_selection("replay")
+        if sel is None:
+            self._replay_say("Pick a season, round and session first")
+            return
+        year, rnd, code = sel
+        self._replay_pause()
+        self._replay = None
+        self._replay_say("Loading…")
+        self._set_busy(True)
+
+        def work():
+            try:
+                rp = teldata.get_replay(
+                    year, rnd, code, team_colors=TEAM_COLORS,
+                    progress=lambda m: self.root.after(
+                        0, lambda mm=m: self._replay_say(mm)))
+                err = None
+            except Exception as exc:
+                rp, err = None, exc
+            self.root.after(0, lambda: self._replay_ready(rp, err))
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _replay_ready(self, rp, err):
+        self._set_busy(False)
+        if err or rp is None:
+            self._replay_say(f"Could not load that session: {err}")
+            self._set_status(f"Replay error: {err}")
+            return
+        self._replay = rp
+        self._replay_frame = 0.0
+        self._replay_focus = rp.drivers[0].info.abbr if rp.drivers else None
+        self._replay_say(
+            f"{rp.year} {rp.event} · {rp.session_name} · "
+            f"{len(rp.drivers)} cars · {rp.duration / 60:.0f} min")
+        self._replay_order_note.configure(
+            text="BY POSITION" if rp.race_like else "BY BEST LAP")
+        try:
+            self._replay_scrub.configure(to=max(1, rp.n_frames - 1))
+        except tk.TclError:
+            pass
+        self._replay_build_scene()
+        self._replay_render(force=True)
+        self._set_status(f"Replay loaded · {rp.event} {rp.session_name}")
+
+    # ── Replay scene ──
+
+    def _replay_transform(self, cw, ch):
+        """Fit the circuit into the canvas, preserving aspect ratio.
+
+        Canvas Y grows downwards while track coordinates grow upwards, so
+        the Y term is negated — without that every circuit renders
+        mirrored.
+        """
+        rp = self._replay
+        x0, y0, x1, y1 = rp.bounds()
+        pad = 46
+        span_x = max(1e-6, x1 - x0)
+        span_y = max(1e-6, y1 - y0)
+        scale = min((cw - 2 * pad) / span_x, (ch - 2 * pad) / span_y)
+        off_x = (cw - span_x * scale) / 2 - x0 * scale
+        off_y = (ch + span_y * scale) / 2 + y0 * scale
+        return scale, off_x, off_y
+
+    def _replay_pt(self, x, y):
+        scale, off_x, off_y = self._replay_tf
+        return x * scale + off_x, off_y - y * scale
+
+    def _replay_canvas_resized(self, _event=None):
+        # Debounce, same as the visualization tab: dragging the window
+        # fires Configure dozens of times a second and rebuilding the
+        # circuit each time is far too expensive.
+        if self._replay is None:
+            return
+        cw = self.replay_canvas.winfo_width()
+        ch = self.replay_canvas.winfo_height()
+        if cw < 200 or ch < 200 or (cw, ch) == self._replay_last_size:
+            return
+        if self._replay_resize_job is not None:
+            try:
+                self.root.after_cancel(self._replay_resize_job)
+            except (ValueError, tk.TclError):
+                pass
+        self._replay_resize_job = self.root.after(120, self._do_replay_resize)
+
+    def _do_replay_resize(self):
+        self._replay_resize_job = None
+        if self._replay is None:
+            return
+        cw = self.replay_canvas.winfo_width()
+        ch = self.replay_canvas.winfo_height()
+        if cw < 200 or ch < 200:
+            return
+        self._replay_last_size = (cw, ch)
+        self._replay_build_scene()
+        self._replay_render(force=True)
+
+    def _replay_build_scene(self):
+        """Draw the static circuit and create one marker per car."""
+        rp = self._replay
+        canvas = self.replay_canvas
+        canvas.delete("all")
+        self._replay_car_items = {}
+        if rp is None:
+            return
+
+        cw = max(canvas.winfo_width(), 200)
+        ch = max(canvas.winfo_height(), 200)
+        self._replay_tf = self._replay_transform(cw, ch)
+
+        pts = []
+        for x, y in zip(rp.track_x, rp.track_y):
+            px, py = self._replay_pt(float(x), float(y))
+            pts.extend((px, py))
+        if len(pts) >= 6:
+            # Close the loop, then lay a light racing surface over a wider
+            # dark kerb so the track reads as a ribbon, not a wire.
+            pts.extend(pts[:2])
+            canvas.create_line(*pts, fill="#33333D", width=13,
+                               capstyle="round", joinstyle="round",
+                               smooth=True)
+            canvas.create_line(*pts, fill="#1F1F27", width=9,
+                               capstyle="round", joinstyle="round",
+                               smooth=True)
+            # Start / finish line.
+            sx, sy = self._replay_pt(float(rp.track_x[0]), float(rp.track_y[0]))
+            canvas.create_oval(sx - 5, sy - 5, sx + 5, sy + 5,
+                               fill=WHITE, outline="")
+
+        for x, y, label in rp.corners:
+            px, py = self._replay_pt(x, y)
+            canvas.create_text(px, py, text=label, fill=MUTED,
+                               font=(self.MONO, 7))
+
+        canvas.create_text(
+            14, 14, anchor="nw",
+            text=f"{rp.year}  {rp.event.upper()}",
+            fill=WHITE, font=("Helvetica Neue", 13, "bold"))
+        canvas.create_text(
+            14, 33, anchor="nw", text=rp.session_name.upper(),
+            fill=GOLD, font=(self.MONO, 9, "bold"))
+
+        for d in rp.drivers:
+            color = d.info.color or GRAY
+            dot = canvas.create_oval(0, 0, 0, 0, fill=color,
+                                     outline=BG, width=1)
+            txt = canvas.create_text(0, 0, text=d.info.abbr, fill=WHITE,
+                                     font=(self.MONO, 7, "bold"))
+            self._replay_car_items[d.info.abbr] = (dot, txt)
+
+    # ── Replay transport ──
+
+    def _replay_toggle_play(self):
+        if self._replay is None:
+            self._replay_say("Load a session first")
+            return
+        if self._replay_playing:
+            self._replay_pause()
+        else:
+            self._replay_play()
+
+    def _replay_play(self):
+        if self._replay is None or self._replay_playing:
+            return
+        # Restarting from the end would sit on a frozen final frame.
+        if self._replay_frame >= self._replay.n_frames - 1:
+            self._replay_frame = 0.0
+        self._replay_playing = True
+        self._replay_play_btn._label.configure(text="⏸  PAUSE")
+        self._replay_last_wall = time.perf_counter()
+        self._replay_tick()
+
+    def _replay_pause(self):
+        self._replay_playing = False
+        if self._replay_after is not None:
+            try:
+                self.root.after_cancel(self._replay_after)
+            except (ValueError, tk.TclError):
+                pass
+            self._replay_after = None
+        btn = getattr(self, "_replay_play_btn", None)
+        if btn is not None:
+            try:
+                btn._label.configure(text="▶  PLAY")
+            except tk.TclError:
+                pass
+
+    def _replay_set_speed(self, mult):
+        self._replay_speed = float(mult)
+        for m, btn in getattr(self, "_replay_speed_btns", {}).items():
+            active = (m == mult)
+            btn.configure(bg=GOLD if active else BG_HOVER)
+            btn._label.configure(bg=GOLD if active else BG_HOVER,
+                                 fg=WHITE if active else GRAY)
+            btn._default_bg = GOLD if active else BG_HOVER
+            btn._current_bg = btn._default_bg
+            btn._default_fg = WHITE if active else GRAY
+
+    def _replay_seek_frame(self, frame):
+        if self._replay is None:
+            return
+        self._replay_frame = float(
+            np.clip(frame, 0, self._replay.n_frames - 1))
+        self._replay_render(force=True)
+
+    def _replay_seek_end(self):
+        if self._replay is not None:
+            self._replay_seek_frame(self._replay.n_frames - 1)
+
+    def _replay_step_lap(self, direction):
+        """Jump to the frame where the race leader crosses the line."""
+        rp = self._replay
+        if rp is None or not rp.drivers:
+            return
+        frame = int(self._replay_frame)
+        order = rp.order_at(frame)
+        leader = next((d for d in rp.drivers
+                       if d.info.abbr == order[0]["abbr"]), rp.drivers[0])
+        target = int(leader.lap_number[frame]) + direction
+        target = max(1, target)
+        idx = np.searchsorted(leader.lap_number, target,
+                              side="left" if direction > 0 else "left")
+        self._replay_seek_frame(int(np.clip(idx, 0, rp.n_frames - 1)))
+
+    def _replay_scrubbed(self, value):
+        # ttk.Scale fires this on programmatic writes too; the guard stops
+        # a render-driven update from bouncing back as a fresh seek.
+        if self._replay is None or self._replay_scrub_guard:
+            return
+        try:
+            frame = float(value)
+        except (TypeError, ValueError):
+            return
+        self._replay_frame = float(
+            np.clip(frame, 0, self._replay.n_frames - 1))
+        self._replay_render(force=True)
+
+    def _replay_focus_row(self, row):
+        if getattr(row, "_abbr", None):
+            self._replay_focus = row._abbr
+            self._replay_render(force=True)
+
+    # ── Replay playback loop ──
+
+    def _replay_tick(self):
+        if not self._replay_playing or self._current_view != "replay":
+            return
+        rp = self._replay
+        if rp is None:
+            return
+
+        now = time.perf_counter()
+        dt = now - self._replay_last_wall
+        self._replay_last_wall = now
+        # A dragged or occluded window can hand us a huge dt; clamp it so
+        # the cars don't teleport half a race on resume.
+        dt = min(max(dt, 0.0), 0.25)
+
+        self._replay_frame += dt * rp.hz * self._replay_speed
+        if self._replay_frame >= rp.n_frames - 1:
+            self._replay_frame = float(rp.n_frames - 1)
+            self._replay_render(force=True)
+            self._replay_pause()
+            self._set_status("Replay finished")
+            return
+
+        self._replay_render()
+        self._replay_after = self.root.after(40, self._replay_tick)
+
+    def _replay_render(self, force=False):
+        """Paint one frame: cars, timing screen, HUD, transport readouts.
+
+        Car positions move every frame; the timing screen and HUD refresh
+        at ~5 Hz.  Re-configuring 24 rows of labels 25 times a second is
+        pure overhead — the numbers can't be read that fast anyway.
+        """
+        rp = self._replay
+        if rp is None:
+            return
+        frame = int(np.clip(self._replay_frame, 0, rp.n_frames - 1))
+        canvas = self.replay_canvas
+
+        for d in rp.drivers:
+            items = self._replay_car_items.get(d.info.abbr)
+            if items is None:
+                continue
+            dot, txt = items
+            x, y = float(d.x[frame]), float(d.y[frame])
+            if not (math.isfinite(x) and math.isfinite(y)):
+                canvas.itemconfigure(dot, state="hidden")
+                canvas.itemconfigure(txt, state="hidden")
+                continue
+            px, py = self._replay_pt(x, y)
+            focused = (d.info.abbr == self._replay_focus)
+            r = 8 if focused else 5.5
+            canvas.coords(dot, px - r, py - r, px + r, py + r)
+            canvas.coords(txt, px, py - r - 7)
+            live = bool(d.on_track[frame])
+            canvas.itemconfigure(dot, state="normal",
+                                 width=2 if focused else 1,
+                                 outline=WHITE if focused else BG)
+            canvas.itemconfigure(
+                txt, state="normal" if (focused or live) else "hidden",
+                fill=WHITE if focused else GRAY)
+
+        now = time.perf_counter()
+        if not force and (now - getattr(self, "_replay_last_panel", 0.0)) < 0.2:
+            return
+        self._replay_last_panel = now
+
+        self._replay_render_timing(rp, frame)
+        self._replay_render_hud(rp, frame)
+
+        elapsed = float(rp.t[frame] - rp.t[0])
+        self._replay_clock.configure(
+            text=f"{int(elapsed // 3600):02d}:"
+                 f"{int(elapsed // 60) % 60:02d}:{int(elapsed % 60):02d}")
+        lead_lap = max((int(d.lap_number[frame]) for d in rp.drivers),
+                       default=0)
+        total = f" / {rp.total_laps}" if rp.total_laps else ""
+        self._replay_lap_lbl.configure(
+            text=f"LAP {lead_lap}{total}" if rp.race_like else "PRACTICE")
+
+        self._replay_scrub_guard = True
+        try:
+            self._replay_scrub_var.set(frame)
+        finally:
+            self._replay_scrub_guard = False
+
+    def _replay_render_timing(self, rp, frame):
+        order = rp.order_at(frame)
+        for i, row in enumerate(self._replay_rows):
+            if i >= len(order):
+                row.pack_forget()
+                row._abbr = None
+                continue
+            entry = order[i]
+            row._abbr = entry["abbr"]
+            if not row.winfo_ismapped():
+                row.pack(fill=tk.X, pady=1)
+
+            focused = entry["abbr"] == self._replay_focus
+            bg = BG_HOVER if focused else BG_SURFACE
+            cells = row._cells
+            row.configure(bg=bg)
+            cells["accent"].configure(bg=entry["color"] or GRAY)
+            cells["pos"].configure(text=f"{entry['pos']:>2}", bg=bg)
+            cells["abbr"].configure(
+                text=entry["abbr"], bg=bg,
+                fg=MUTED if entry["retired"] else WHITE)
+            cells["lap"].configure(text=str(entry["lap"]), bg=bg)
+            cells["gap"].configure(
+                text="OUT" if entry["retired"]
+                else teldata.fmt_gap(entry["gap"], entry["laps_down"]),
+                bg=bg, fg=GOLD if entry["pos"] == 1 else WHITE)
+            cells["best"].configure(
+                text=teldata.fmt_laptime(entry["best"]), bg=bg)
+            compound = (entry["compound"] or "")[:1].upper()
+            cells["tyre"].configure(
+                text=compound, bg=bg,
+                fg=teldata.compound_color(entry["compound"]))
+
+    def _replay_render_hud(self, rp, frame):
+        if self._replay_focus is None:
+            return
+        hud = rp.telemetry_at(self._replay_focus, frame)
+        if hud is None:
+            return
+        color = hud["color"] or GOLD
+        self._hud_accent.configure(bg=color)
+        self._hud_driver.configure(text=self._replay_focus)
+        self._hud_team.configure(text=(hud["team"] or "").upper())
+
+        speed = hud["speed"]
+        self._hud_speed.configure(text=f"{speed:.0f}" if speed else "—")
+        gear = hud["gear"]
+        self._hud_gear.configure(text=f"{int(gear)}" if gear else "—")
+
+        for name, value in (("throttle", hud["throttle"]),
+                            ("brake", (hud["brake"] or 0) * 100.0)):
+            cv, rect = self._hud_bars[name]
+            width = max(cv.winfo_width(), 1)
+            pct = 0.0 if value is None else max(0.0, min(100.0, value))
+            cv.coords(rect, 0, 0, width * pct / 100.0, 10)
+
+        rpm = hud["rpm"]
+        self._hud_chips["rpm"].configure(text=f"{rpm:,.0f}" if rpm else "—")
+        # DRS status codes: 10, 12 and 14 mean the flap is actually open;
+        # 8 only means the driver is within a second and eligible.
+        drs = hud["drs"] or 0
+        self._hud_chips["drs"].configure(
+            text="OPEN" if drs >= 10 else "—",
+            fg=GREEN if drs >= 10 else MUTED)
+        compound = hud["compound"]
+        self._hud_chips["tyre"].configure(
+            text=(compound or "—").title(),
+            fg=teldata.compound_color(compound))
+        self._hud_chips["lap"].configure(text=str(hud["lap"]))
 
     # ── Track visualization ──
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -70,7 +70,8 @@ need to follow the race.
 ┌─────────────────── app.py (Tk + PIL) ──────────────────┐
 │  Header (F1 wordmark — clickable home button)          │
 │  Tab bar:  Predict · Backtest · Visualization ·         │
-│            Team Radio · Race Replays · Refresh         │
+│            Team Radio · Race Replays · Telemetry ·      │
+│            Session Replay · Refresh                     │
 │                                                        │
 │  ┌──── Predictions panel ───┐ ┌──── Insight panel ───┐ │
 │  │  Podium card + grid      │ │ Model stats          │ │
@@ -90,6 +91,15 @@ need to follow the race.
             │  run_predictions_all_…() │
             │  schedule cache          │
             │  singleton enforcement   │
+            └──────────────────────────┘
+                              │
+            ┌──── telemetry.py ────────┐
+            │  load_session()          │
+            │  lap_telemetry()         │
+            │  compare_laps() + delta  │
+            │  build_replay()          │
+            │  Replay.order_at()       │
+            │  replay disk cache       │
             └──────────────────────────┘
                               │
                               ▼
@@ -189,21 +199,87 @@ need to follow the race.
 - **F5.5.** Schedule loads on a background thread so the UI never
   freezes while the schedule cache is populating.
 
-### 6.6 Header / Home
+### 6.6 Telemetry Overlay (NEW)
 
-- **F6.1.** F1 logo and "Apex" / "AI" wordmark act as a **home button**
+- **F6.1.** Two independent lap selectors (**Car A** / **Car B**), each
+  a season → round → session → driver → lap chain. Lap defaults to the
+  driver's fastest.
+- **F6.2.** *LINK SESSIONS* (on by default) pins Car B to Car A's
+  session for the common two-team-mates case, and locks B's session
+  combos. Unlinking enables **cross-session and cross-season**
+  comparison — the year-vs-year use case.
+- **F6.3.** Laps are aligned on **distance around the lap**, not on
+  wall-clock, which is what makes lap-vs-lap, compound-vs-compound and
+  year-vs-year the same code path.
+- **F6.4.** Rendered output:
+  - Summary cards per lap: lap time, event/session/lap, tyre compound
+    + age, top speed, average speed, wide-open-throttle %, braking %.
+  - Headline **lap delta** with the faster driver named.
+  - Trace stack against distance: **speed**, **running delta**
+    (filled toward whoever is ahead), **throttle**, **brake + DRS**
+    bands, and **gear**.
+  - **Mini-sector dominance**: the lap's track map coloured by which
+    driver owns each of 25 mini-sectors, beside a bar chart of the
+    per-sector time swing that sums to the final delta.
+- **F6.5.** Team-mates share a livery colour; when the two selected
+  drivers resolve to the same colour, Car B is shifted to a light tint
+  so the traces stay distinguishable.
+- **F6.6.** Comparing laps from different circuits is permitted but
+  flagged with an inline warning, since the distance axis then only
+  lines up by length.
+- **F6.7.** All loading happens on worker threads with progress
+  reported inline; stale results are discarded if the selection moves
+  on while a fetch is in flight.
+
+### 6.7 Session Replay (NEW)
+
+- **F7.1.** Season → round → session picker, restricted to **2018 and
+  later** because FastF1 carries no car/position telemetry before then.
+- **F7.2.** Every driver's position and car-telemetry streams are
+  resampled onto one common 4 Hz time grid, so any frame can be
+  rendered directly without re-reading the source streams.
+- **F7.3.** **Track map** traced from the session's own position data
+  (the fastest lap is used as the cleanest single loop), with numbered
+  corners, a start/finish marker, and one live marker per car.
+- **F7.4.** **Timing screen**: position, driver, current lap, gap,
+  tyre compound and rolling personal best.
+  - Race-like sessions are ordered by **track progress** — each car is
+    projected onto the circuit centreline to give a continuous
+    "laps completed + fraction of the current lap" value, and the gap
+    is the time since the leader was at that same point.
+  - Qualifying and practice are ordered by **best lap set so far**,
+    matching the real broadcast screens.
+- **F7.5.** **Telemetry HUD** for the focused car: speed, gear,
+  throttle/brake bars, RPM, DRS state and tyre. Clicking any timing row
+  moves the focus.
+- **F7.6.** **Transport**: play/pause, 0.5× → 16× playback, a scrub bar,
+  ±1 lap jumps, jump to start/end, plus a session clock and lap counter.
+  Playback auto-pauses at the end and restarts from the top if played
+  again.
+- **F7.7.** Leaving the tab pauses playback rather than tearing the
+  replay down, so returning resumes in place.
+- **F7.8.** Built replays are pickled to `replay_cache/` under a
+  version-stamped key; a corrupt or stale cache silently rebuilds.
+- **F7.9.** Car markers update every frame (~25 fps); the timing screen
+  and HUD refresh at ~5 Hz, since re-configuring two dozen label rows at
+  full frame rate is pure overhead.
+
+### 6.8 Header / Home
+
+- **F8.1.** F1 logo and "Apex" / "AI" wordmark act as a **home button**
   — clicking returns to the predictions view of the last predicted
-  race, stops any running radio playback, and resets the view state.
-- **F6.2.** Hover affordance: brand mark dims/brightens to telegraph
+  race, stops any running radio playback and replay playback, and
+  resets the view state.
+- **F8.2.** Hover affordance: brand mark dims/brightens to telegraph
   that it's interactive.
 
-### 6.7 Singleton
+### 6.9 Singleton
 
-- **F7.1.** Launching `app.py` while another instance is already
+- **F9.1.** Launching `app.py` while another instance is already
   running kills the prior PID via `SIGTERM` (escalates to `SIGKILL`
   after a 2 s grace period) and claims an exclusive lockfile
   (`.apex_ai.lock`).
-- **F7.2.** Sweep the OS process list for any *other* python process
+- **F9.2.** Sweep the OS process list for any *other* python process
   whose command line points at `app.py`, not just the lockfile PID,
   so stale instances from terminals or IDE runs are also reaped.
 
@@ -217,7 +293,11 @@ need to follow the race.
 | **Backtest 96 races** | ≤ 60 s (currently ~28 s) |
 | **Visualization frame rate** | 30 fps sustained on M-series Macs |
 | **Replays tab open** | ≤ 200 ms perceived latency |
-| **Memory** | ≤ 800 MB resident |
+| **Telemetry comparison (session cached)** | ≤ 3 s from *Compare Laps* to rendered traces |
+| **Session replay build (first time)** | ≤ 90 s for a race, dominated by the telemetry download |
+| **Session replay open (cached)** | ≤ 2 s from `replay_cache/` |
+| **Replay playback frame rate** | 25 fps for car markers, 5 Hz for timing screen + HUD |
+| **Memory** | ≤ 800 MB resident; a built race replay adds ≈ 30 MB |
 | **Offline tolerance** | App must load from caches if FastF1 backends are down — schedule disk cache + stale-OK fallback |
 | **Accessibility** | Hand cursors on every clickable element, ≥ 11 pt fonts, WCAG-AA contrast on text |
 | **Singleton** | Exactly one bot instance can run at any time |
@@ -260,6 +340,9 @@ need to follow the race.
 | Parallelism | `joblib.Parallel` (threading backend) | GBM releases the GIL during numpy ops; threading avoids the pickle hit of process workers. |
 | Data | FastF1 + FIA livetiming + OpenF1 + fullraces.com | All free; FastF1 cache lives in `cache/`. |
 | Audio | `playsound3` (via `f1radio[playback]`) | Native APIs, no `afplay`/`ffplay` PATH dependency. |
+| Telemetry charts | Matplotlib rendered to PIL, shown as a Tk image | Multi-panel trace stacks and the dominance map are static once drawn; rasterising once beats re-drawing on a Tk canvas. |
+| Replay playback | Plain Tk canvas item updates on `after()` | Only the car markers move per frame, so moving ~20 canvas ovals is far cheaper than re-rendering a figure. |
+| Replay cache | `pickle` of flat numpy arrays in `replay_cache/` | A built replay is just arrays on a common time grid; version-stamped so a schema change invalidates rather than mis-loads. |
 | Packaging | PyInstaller (`build_mac.sh`) | Produces a standalone `.app` bundle. |
 
 ## 11. Risks & Mitigations

--- a/telemetry.py
+++ b/telemetry.py
@@ -1,0 +1,1387 @@
+#!/usr/bin/env python3
+"""
+ApexAI – telemetry & session replay data layer.
+
+This module is the data half of the two telemetry features:
+
+  * **Telemetry comparison** – pull a single lap's car data (speed,
+    throttle, brake, gear, RPM, DRS) for any driver in any session of any
+    season, align two laps on *distance around the lap*, and derive the
+    time delta plus mini-sector dominance.  Because everything is keyed on
+    distance rather than wall-clock, the two laps do not have to come from
+    the same session: lap-vs-lap, compound-vs-compound and year-vs-year
+    overlays all fall out of the same code path.
+
+  * **Session replay** – resample every driver's position + car telemetry
+    onto one common time grid, project each car onto the track centreline
+    to get a continuous "laps completed + fraction of the current lap"
+    progress value, and hand the UI a compact set of numpy arrays it can
+    scrub through at any playback speed.
+
+Everything here is pure data: no Tk, no matplotlib.  `app.py` owns the
+rendering.  All heavy results are memoised in-process and mirrored to a
+pickle on disk so re-opening a session you have already watched is
+instant.
+
+Data source is FastF1 throughout, which is the same timing feed the rest
+of ApexAI already runs on.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import pickle
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+import fastf1
+
+# Base path mirrors prediction.py so a frozen build writes to the same
+# writable app-support directory instead of inside the .app bundle.
+if getattr(sys, "frozen", False):
+    _BASE = Path.home() / "Library" / "Application Support" / "F1 Winner Predictor"
+    _BASE.mkdir(parents=True, exist_ok=True)
+else:
+    _BASE = Path(__file__).parent
+
+CACHE_DIR = _BASE / "cache"
+CACHE_DIR.mkdir(exist_ok=True)
+REPLAY_CACHE_DIR = _BASE / "replay_cache"
+REPLAY_CACHE_DIR.mkdir(exist_ok=True)
+
+logging.getLogger("fastf1").setLevel(logging.WARNING)
+
+try:
+    fastf1.Cache.enable_cache(str(CACHE_DIR))
+except Exception:
+    # prediction.py may have enabled it already; enabling twice is a no-op
+    # in recent FastF1 but older versions raise.
+    pass
+
+# Bump when the shape of anything we pickle changes so stale replay caches
+# are discarded rather than unpickled into the wrong dataclass.
+REPLAY_CACHE_VERSION = "rp1"
+
+# ---------------------------------------------------------------------------
+# Session catalogue
+# ---------------------------------------------------------------------------
+
+# FastF1 accepts these identifiers directly.  Order is "most interesting
+# first" so the UI's default selection lands on the race.
+SESSION_CHOICES: list[tuple[str, str]] = [
+    ("R", "Race"),
+    ("Q", "Qualifying"),
+    ("S", "Sprint"),
+    ("SQ", "Sprint Qualifying"),
+    ("SS", "Sprint Shootout"),
+    ("FP1", "Practice 1"),
+    ("FP2", "Practice 2"),
+    ("FP3", "Practice 3"),
+]
+
+SESSION_LABELS = dict(SESSION_CHOICES)
+
+# Sessions where running order is a live race order (progress round the
+# track).  Everything else is ranked by best lap time, exactly like a real
+# timing screen.
+RACE_LIKE = {"R", "S"}
+
+# Tyre compound colours, matching the official Pirelli marking colours.
+COMPOUND_COLORS = {
+    "SOFT": "#E10600",
+    "MEDIUM": "#FFD12E",
+    "HARD": "#F0F0EC",
+    "INTERMEDIATE": "#43B02A",
+    "WET": "#0067AD",
+    "TEST-UNKNOWN": "#8F8F98",
+    "UNKNOWN": "#8F8F98",
+}
+
+
+def compound_color(compound: Optional[str]) -> str:
+    if not compound:
+        return COMPOUND_COLORS["UNKNOWN"]
+    return COMPOUND_COLORS.get(str(compound).upper(), COMPOUND_COLORS["UNKNOWN"])
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+def _to_seconds(series) -> np.ndarray:
+    """Timedelta series -> float seconds, NaT -> nan."""
+    if series is None or len(series) == 0:
+        return np.zeros(0, dtype=np.float64)
+    vals = pd.to_timedelta(pd.Series(series).values)
+    return vals.total_seconds().to_numpy(dtype=np.float64)
+
+
+def fmt_laptime(seconds: Optional[float]) -> str:
+    """1:23.456 style lap time.  Returns '—' for missing values."""
+    if seconds is None:
+        return "—"
+    try:
+        s = float(seconds)
+    except (TypeError, ValueError):
+        return "—"
+    if not math.isfinite(s) or s <= 0:
+        return "—"
+    minutes = int(s // 60)
+    rem = s - minutes * 60
+    if minutes:
+        return f"{minutes}:{rem:06.3f}"
+    return f"{rem:.3f}"
+
+
+def fmt_delta(seconds: Optional[float]) -> str:
+    """Signed gap, e.g. '+0.312' / '-1.204'."""
+    if seconds is None:
+        return "—"
+    try:
+        s = float(seconds)
+    except (TypeError, ValueError):
+        return "—"
+    if not math.isfinite(s):
+        return "—"
+    return f"{s:+.3f}"
+
+
+def fmt_gap(seconds: Optional[float], laps_down: int = 0) -> str:
+    if laps_down > 0:
+        return f"+{laps_down}L"
+    if seconds is None or not math.isfinite(seconds):
+        return "—"
+    if seconds <= 0.0005:
+        return "LEADER"
+    return f"+{seconds:.3f}"
+
+
+def _nan_to_none(v):
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return f if math.isfinite(f) else None
+
+
+def _interp_continuous(grid: np.ndarray, t: np.ndarray,
+                       vals: np.ndarray) -> np.ndarray:
+    """Linear interpolation with edge clamping, nan-safe."""
+    if len(t) == 0:
+        return np.full(grid.shape, np.nan, dtype=np.float32)
+    ok = np.isfinite(t) & np.isfinite(vals)
+    if not ok.any():
+        return np.full(grid.shape, np.nan, dtype=np.float32)
+    t = t[ok]
+    vals = vals[ok]
+    order = np.argsort(t, kind="stable")
+    return np.interp(grid, t[order], vals[order]).astype(np.float32)
+
+
+def _interp_discrete(grid: np.ndarray, t: np.ndarray,
+                     vals: np.ndarray) -> np.ndarray:
+    """Sample-and-hold for channels that must not be blended (gear, DRS,
+    brake).  Interpolating a gear between 3 and 5 would invent a 4 that was
+    never selected, so we take the most recent actual sample instead."""
+    if len(t) == 0:
+        return np.zeros(grid.shape, dtype=np.float32)
+    order = np.argsort(t, kind="stable")
+    t = t[order]
+    vals = vals[order]
+    idx = np.searchsorted(t, grid, side="right") - 1
+    np.clip(idx, 0, len(t) - 1, out=idx)
+    return vals[idx].astype(np.float32)
+
+
+def _resample_path(x: np.ndarray, y: np.ndarray,
+                   n_out: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Resample an (x, y) polyline to `n_out` evenly-arc-spaced points.
+
+    Returns (xs, ys, cumulative_distance) where the distance array is in
+    the same units as the input coordinates.
+    """
+    ok = np.isfinite(x) & np.isfinite(y)
+    x = x[ok].astype(np.float64)
+    y = y[ok].astype(np.float64)
+    if len(x) < 4:
+        return x, y, np.arange(len(x), dtype=np.float64)
+
+    seg = np.hypot(np.diff(x), np.diff(y))
+    s = np.concatenate([[0.0], np.cumsum(seg)])
+    total = s[-1]
+    if total <= 0:
+        return x, y, s
+    # Drop duplicate arc-length samples; np.interp needs a strictly
+    # increasing x-array to behave.
+    keep = np.concatenate([[True], np.diff(s) > 1e-9])
+    s = s[keep]
+    x = x[keep]
+    y = y[keep]
+
+    grid = np.linspace(0.0, total, n_out)
+    return np.interp(grid, s, x), np.interp(grid, s, y), grid
+
+
+# ---------------------------------------------------------------------------
+# Value objects
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DriverInfo:
+    abbr: str
+    number: str
+    name: str
+    team: str
+    color: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.abbr} · {self.name}"
+
+
+@dataclass
+class LapInfo:
+    """One row of a driver's lap list, pre-formatted for a picker."""
+    number: int
+    lap_time: Optional[float]
+    compound: Optional[str]
+    tyre_life: Optional[float]
+    stint: Optional[int]
+    position: Optional[int]
+    is_personal_best: bool
+    is_accurate: bool
+    deleted: bool
+
+    @property
+    def label(self) -> str:
+        comp = (self.compound or "?")[:1].upper()
+        star = " ★" if self.is_personal_best else ""
+        return f"L{self.number:>2}  {fmt_laptime(self.lap_time)}  [{comp}]{star}"
+
+
+@dataclass
+class LapTelemetry:
+    """A single lap's car trace, resampled onto an even distance grid.
+
+    Everything downstream (overlay charts, delta, mini-sectors) works off
+    the distance grid, which is what lets two laps from completely
+    different sessions be compared.
+    """
+    year: int
+    round_no: int
+    event: str
+    session_code: str
+    session_name: str
+    driver: str
+    driver_name: str
+    team: str
+    color: str
+    lap_number: int
+    lap_time: Optional[float]
+    compound: Optional[str]
+    tyre_life: Optional[float]
+    circuit: str
+
+    distance: np.ndarray          # metres from the start line
+    elapsed: np.ndarray           # seconds since the lap started
+    speed: np.ndarray             # km/h
+    throttle: np.ndarray          # %
+    brake: np.ndarray             # 0/1
+    gear: np.ndarray
+    rpm: np.ndarray
+    drs: np.ndarray               # raw DRS status code
+    x: np.ndarray                 # track map coords
+    y: np.ndarray
+
+    @property
+    def label(self) -> str:
+        return (f"{self.driver} · {self.year} {self.event} "
+                f"{self.session_name} · L{self.lap_number}")
+
+    @property
+    def short_label(self) -> str:
+        return f"{self.driver} {self.year} L{self.lap_number}"
+
+    # -- derived stats, all cheap enough to compute on demand --
+
+    @property
+    def top_speed(self) -> float:
+        return float(np.nanmax(self.speed)) if len(self.speed) else float("nan")
+
+    @property
+    def avg_speed(self) -> float:
+        return float(np.nanmean(self.speed)) if len(self.speed) else float("nan")
+
+    @property
+    def wot_pct(self) -> float:
+        """Share of the lap *distance* spent at wide-open throttle (95 %+).
+
+        Measured against distance rather than time, so a slower lap isn't
+        flattered by spending longer pinned at the stop.
+        """
+        if not len(self.throttle):
+            return float("nan")
+        return float(np.mean(self.throttle >= 95.0) * 100.0)
+
+    @property
+    def braking_pct(self) -> float:
+        if not len(self.brake):
+            return float("nan")
+        return float(np.mean(self.brake > 0.5) * 100.0)
+
+
+@dataclass
+class Comparison:
+    """Two laps aligned on a shared distance grid."""
+    ref: LapTelemetry
+    other: LapTelemetry
+    distance: np.ndarray
+    ref_elapsed: np.ndarray
+    other_elapsed: np.ndarray
+    delta: np.ndarray             # other - ref, seconds (positive = other slower)
+    minisector_edges: np.ndarray  # distance boundaries, len = n+1
+    minisector_winner: np.ndarray # 0 = ref, 1 = other, per mini-sector
+    minisector_delta: np.ndarray  # per-sector time difference
+    same_circuit: bool
+
+    @property
+    def final_delta(self) -> Optional[float]:
+        if not len(self.delta):
+            return None
+        return float(self.delta[-1])
+
+
+@dataclass
+class ReplayDriver:
+    info: DriverInfo
+    x: np.ndarray            # float32, per frame
+    y: np.ndarray
+    progress: np.ndarray     # float32 laps completed + fraction of current lap
+    on_track: np.ndarray     # bool, per frame
+    speed: np.ndarray
+    throttle: np.ndarray
+    brake: np.ndarray
+    gear: np.ndarray
+    rpm: np.ndarray
+    drs: np.ndarray
+    lap_number: np.ndarray   # int16, current lap (1-based)
+    compound: list           # per frame index -> compound string (run-length decoded)
+    best_lap: np.ndarray     # float32, best lap time set *so far* at each frame
+    finished_at: Optional[float]   # session-time seconds when they stopped
+
+
+@dataclass
+class Replay:
+    """Everything the replay UI needs, as flat arrays on one time grid."""
+    year: int
+    round_no: int
+    event: str
+    session_code: str
+    session_name: str
+    circuit: str
+    hz: float
+    t: np.ndarray                 # session-time seconds, len = n_frames
+    drivers: list                 # list[ReplayDriver], results order
+    track_x: np.ndarray           # centreline for drawing the map
+    track_y: np.ndarray
+    track_length: float
+    corners: list                 # list[(x, y, label)]
+    total_laps: Optional[int]
+    race_like: bool
+
+    @property
+    def n_frames(self) -> int:
+        return len(self.t)
+
+    @property
+    def duration(self) -> float:
+        return float(self.t[-1] - self.t[0]) if len(self.t) > 1 else 0.0
+
+    def bounds(self) -> tuple[float, float, float, float]:
+        xs = [self.track_x] + [d.x for d in self.drivers]
+        ys = [self.track_y] + [d.y for d in self.drivers]
+        xs = np.concatenate([a[np.isfinite(a)] for a in xs if len(a)])
+        ys = np.concatenate([a[np.isfinite(a)] for a in ys if len(a)])
+        if not len(xs) or not len(ys):
+            return (0.0, 0.0, 1.0, 1.0)
+        return (float(xs.min()), float(ys.min()),
+                float(xs.max()), float(ys.max()))
+
+    # -- live timing screen ------------------------------------------------
+
+    def order_at(self, frame: int) -> list:
+        """Running order at `frame`, as a list of dicts ready to render.
+
+        Race-like sessions are ordered by track progress (the classic
+        "who is physically ahead" timing screen).  Qualifying and practice
+        are ordered by the best lap time set so far, which is what those
+        screens actually show.
+        """
+        frame = int(np.clip(frame, 0, max(0, self.n_frames - 1)))
+        rows = []
+
+        if self.race_like:
+            live = [(d, float(d.progress[frame])) for d in self.drivers]
+            live.sort(key=lambda p: -p[1] if math.isfinite(p[1]) else 1e9)
+            leader, leader_prog = live[0] if live else (None, 0.0)
+            for pos, (d, prog) in enumerate(live, start=1):
+                laps_down = 0
+                # The leader's gap is zero by definition, which is what
+                # renders as "LEADER"; None is reserved for a gap we
+                # genuinely could not compute.
+                gap = 0.0
+                if leader is not None and d is not leader:
+                    diff = leader_prog - prog
+                    laps_down = int(diff) if diff >= 1.0 else 0
+                    gap = self._time_gap(leader, prog, frame)
+                rows.append(self._row(d, pos, frame, gap, laps_down))
+        else:
+            def _key(d):
+                b = float(d.best_lap[frame])
+                return b if math.isfinite(b) and b > 0 else 1e9
+            live = sorted(self.drivers, key=_key)
+            best = _key(live[0]) if live else 1e9
+            for pos, d in enumerate(live, start=1):
+                own = _key(d)
+                gap = None
+                if own < 1e9 and best < 1e9:
+                    # Zero for whoever holds the session best, so P1 reads
+                    # as "LEADER" rather than "+0.000".
+                    gap = own - best
+                rows.append(self._row(d, pos, frame, gap, 0))
+        return rows
+
+    def _time_gap(self, leader: ReplayDriver, prog: float,
+                  frame: int) -> Optional[float]:
+        """How long ago the current leader was at this car's track position.
+
+        Progress is monotonic, so a plain interpolation of the leader's
+        progress-vs-time curve inverts cleanly into a time gap — the same
+        definition a real timing screen uses.
+        """
+        lp = leader.progress[:frame + 1]
+        if len(lp) < 2 or not math.isfinite(prog):
+            return None
+        # np.interp needs an increasing x; progress is built monotonic.
+        crossed = np.interp(prog, lp, self.t[:frame + 1],
+                            left=float(self.t[0]), right=float(self.t[frame]))
+        gap = float(self.t[frame] - crossed)
+        return gap if math.isfinite(gap) and gap >= 0 else None
+
+    def _row(self, d: ReplayDriver, pos: int, frame: int,
+             gap: Optional[float], laps_down: int) -> dict:
+        best = float(d.best_lap[frame])
+        return {
+            "pos": pos,
+            "abbr": d.info.abbr,
+            "name": d.info.name,
+            "team": d.info.team,
+            "color": d.info.color,
+            "lap": int(d.lap_number[frame]),
+            "compound": d.compound[frame] if d.compound else None,
+            "gap": gap,
+            "laps_down": laps_down,
+            "best": best if math.isfinite(best) and best > 0 else None,
+            "speed": float(d.speed[frame]),
+            "on_track": bool(d.on_track[frame]),
+            "retired": not bool(d.on_track[frame]) and (
+                d.finished_at is not None and self.t[frame] >= d.finished_at),
+        }
+
+    def telemetry_at(self, abbr: str, frame: int) -> Optional[dict]:
+        """Live channel readout for one driver — the replay HUD."""
+        frame = int(np.clip(frame, 0, max(0, self.n_frames - 1)))
+        for d in self.drivers:
+            if d.info.abbr == abbr:
+                return {
+                    "speed": _nan_to_none(d.speed[frame]),
+                    "throttle": _nan_to_none(d.throttle[frame]),
+                    "brake": _nan_to_none(d.brake[frame]),
+                    "gear": _nan_to_none(d.gear[frame]),
+                    "rpm": _nan_to_none(d.rpm[frame]),
+                    "drs": _nan_to_none(d.drs[frame]),
+                    "lap": int(d.lap_number[frame]),
+                    "compound": d.compound[frame] if d.compound else None,
+                    "color": d.info.color,
+                    "team": d.info.team,
+                }
+        return None
+
+    def trace(self, abbr: str, channel: str, frame: int,
+              window: int) -> tuple[np.ndarray, np.ndarray]:
+        """A rolling slice of one channel, for the HUD's scrolling trace."""
+        frame = int(np.clip(frame, 0, max(0, self.n_frames - 1)))
+        lo = max(0, frame - window)
+        for d in self.drivers:
+            if d.info.abbr == abbr:
+                arr = getattr(d, channel, None)
+                if arr is None:
+                    break
+                return self.t[lo:frame + 1], arr[lo:frame + 1]
+        return np.zeros(0), np.zeros(0)
+
+
+# ---------------------------------------------------------------------------
+# Session loading
+# ---------------------------------------------------------------------------
+
+_SESSION_MEM: dict = {}
+_SESSION_LOCK = threading.Lock()
+
+
+def available_sessions(year: int, round_no: int) -> list[tuple[str, str]]:
+    """Session identifiers that actually exist for this event.
+
+    Falls back to the standard non-sprint weekend if the schedule can't be
+    resolved, so the picker is never empty.
+    """
+    default = [("R", "Race"), ("Q", "Qualifying"),
+               ("FP1", "Practice 1"), ("FP2", "Practice 2"),
+               ("FP3", "Practice 3")]
+    try:
+        event = fastf1.get_event(year, round_no)
+    except Exception:
+        return default
+
+    names = []
+    for i in range(1, 6):
+        try:
+            nm = event.get(f"Session{i}")
+        except Exception:
+            nm = None
+        if isinstance(nm, str) and nm.strip() and nm.strip().lower() != "none":
+            names.append(nm.strip())
+    if not names:
+        return default
+
+    # Map the schedule's human names back onto FastF1 identifiers.
+    name_to_code = {
+        "Practice 1": "FP1", "Practice 2": "FP2", "Practice 3": "FP3",
+        "Qualifying": "Q", "Sprint": "S",
+        "Sprint Qualifying": "SQ", "Sprint Shootout": "SS",
+        "Race": "R",
+    }
+    out = []
+    for nm in names:
+        code = name_to_code.get(nm)
+        if code:
+            out.append((code, nm))
+    if not out:
+        return default
+    # Race first, then quali, then the rest — most-wanted at the top.
+    priority = {"R": 0, "S": 1, "Q": 2, "SQ": 3, "SS": 3,
+                "FP3": 4, "FP2": 5, "FP1": 6}
+    out.sort(key=lambda c: priority.get(c[0], 9))
+    return out
+
+
+def load_session(year: int, round_no: int, code: str,
+                 with_telemetry: bool = False,
+                 progress: Optional[Callable[[str], None]] = None):
+    """Load (and memoise) a FastF1 session.
+
+    `with_telemetry` controls whether car + position streams are pulled.
+    They are a much larger download than laps alone, so the comparison tab
+    asks for them but the lap-list picker does not.  A session already
+    loaded *with* telemetry satisfies a later request without telemetry.
+    """
+    key = (int(year), int(round_no), str(code))
+
+    with _SESSION_LOCK:
+        cached = _SESSION_MEM.get(key)
+    if cached is not None:
+        session, had_tel = cached
+        if had_tel or not with_telemetry:
+            return session
+
+    def _say(msg):
+        if progress:
+            try:
+                progress(msg)
+            except Exception:
+                pass
+
+    _say(f"Fetching {SESSION_LABELS.get(code, code)} · {year} round {round_no}…")
+    session = fastf1.get_session(year, round_no, code)
+    _say("Loading timing data…" if not with_telemetry
+         else "Loading timing + telemetry (first time can take a minute)…")
+    session.load(laps=True, telemetry=with_telemetry,
+                 weather=False, messages=False)
+    _assert_loaded(session, year, round_no, code, with_telemetry)
+
+    with _SESSION_LOCK:
+        _SESSION_MEM[key] = (session, with_telemetry)
+    return session
+
+
+def _assert_loaded(session, year: int, round_no: int, code: str,
+                   with_telemetry: bool) -> None:
+    """Fail loudly when `Session.load()` quietly came back empty.
+
+    FastF1 wraps each loader in `@soft_exceptions`, so a network failure or
+    a session the feed has no data for is logged as a warning and `load()`
+    returns normally with nothing attached.  Every later access then dies
+    on `DataNotLoadedError`, which surfaces to the user as either a bare
+    "no drivers found" or FastF1's own "see Session.load" jargon — neither
+    of which says what actually went wrong.  Check once, here, and say it
+    plainly.
+    """
+    label = f"{SESSION_LABELS.get(code, code)} · {year} round {round_no}"
+    try:
+        laps = session.laps
+    except Exception:
+        raise ValueError(
+            f"No timing data came back for {label}. The F1 timing feed was "
+            f"unreachable, or it has no data for this session yet."
+        ) from None
+    if laps is None or not len(laps):
+        raise ValueError(
+            f"{label} returned an empty timing sheet — the session may not "
+            f"have run yet."
+        )
+    if with_telemetry and not (_safe_stream(session, "pos_data")
+                               or _safe_stream(session, "car_data")):
+        raise ValueError(
+            f"Timing data for {label} loaded, but its car telemetry stream "
+            f"did not. Telemetry only exists from 2018 onwards, and very "
+            f"recent sessions can take a few hours to be published."
+        )
+
+
+def _safe_stream(session, name: str):
+    """`session.pos_data` / `car_data` raise when unloaded rather than
+    returning None, so a plain getattr default is not enough."""
+    try:
+        return getattr(session, name, None)
+    except Exception:
+        return None
+
+
+def session_display_name(session) -> str:
+    try:
+        return str(session.name)
+    except Exception:
+        return "Session"
+
+
+def _safe_total_laps(session) -> Optional[int]:
+    # `total_laps` raises unless the lap-count endpoint came back, which it
+    # doesn't for practice and occasionally fails for older races.
+    try:
+        tl = session.total_laps
+        if tl:
+            return int(tl)
+    except Exception:
+        pass
+    try:
+        return int(session.laps["LapNumber"].max())
+    except Exception:
+        return None
+
+
+def driver_table(session, team_colors: Optional[dict] = None) -> list[DriverInfo]:
+    """Drivers in the session, in classification order."""
+    out: list[DriverInfo] = []
+    try:
+        results = session.results
+    except Exception:
+        results = None
+
+    if results is not None and len(results):
+        for _, row in results.iterrows():
+            abbr = str(row.get("Abbreviation") or "").strip()
+            if not abbr:
+                continue
+            team = str(row.get("TeamName") or "").strip()
+            name = str(row.get("FullName") or "").strip() or abbr
+            color = None
+            if team_colors:
+                color = team_colors.get(team)
+            if not color:
+                tc = str(row.get("TeamColor") or "").strip()
+                color = f"#{tc}" if tc and not tc.startswith("#") else (tc or None)
+            out.append(DriverInfo(
+                abbr=abbr,
+                number=str(row.get("DriverNumber") or "").strip(),
+                name=name,
+                team=team,
+                color=color or "#8F8F98",
+            ))
+
+    if out:
+        return out
+
+    # Results can be empty for some practice sessions — fall back to laps.
+    try:
+        laps = session.laps
+    except Exception:
+        return out
+    seen = set()
+    for _, row in laps.iterrows():
+        abbr = str(row.get("Driver") or "").strip()
+        if not abbr or abbr in seen:
+            continue
+        seen.add(abbr)
+        team = str(row.get("Team") or "").strip()
+        color = (team_colors or {}).get(team, "#8F8F98")
+        out.append(DriverInfo(abbr=abbr,
+                              number=str(row.get("DriverNumber") or "").strip(),
+                              name=abbr, team=team, color=color))
+    return out
+
+
+def lap_table(session, abbr: str) -> list[LapInfo]:
+    """Every lap the driver completed, newest data first formatted for a
+    picker.  Laps without a time (in/out laps, aborted runs) are kept —
+    you may well want to look at an out-lap's telemetry."""
+    try:
+        laps = session.laps.pick_drivers(abbr)
+    except Exception:
+        return []
+    if laps is None or not len(laps):
+        return []
+
+    out: list[LapInfo] = []
+    for _, row in laps.iterrows():
+        num = row.get("LapNumber")
+        if pd.isna(num):
+            continue
+        lt = row.get("LapTime")
+        lt_s = None if pd.isna(lt) else float(pd.Timedelta(lt).total_seconds())
+        comp = row.get("Compound")
+        comp = None if (comp is None or pd.isna(comp)) else str(comp)
+        out.append(LapInfo(
+            number=int(num),
+            lap_time=lt_s,
+            compound=comp,
+            tyre_life=_nan_to_none(row.get("TyreLife")),
+            stint=int(row["Stint"]) if not pd.isna(row.get("Stint")) else None,
+            position=int(row["Position"]) if not pd.isna(row.get("Position")) else None,
+            is_personal_best=bool(row.get("IsPersonalBest") is True),
+            is_accurate=bool(row.get("IsAccurate") is True),
+            deleted=bool(row.get("Deleted") is True),
+        ))
+    return out
+
+
+def _pick_fastest(laps):
+    """`Laps.pick_fastest()` with a sane fallback.
+
+    By default FastF1 only considers laps the timing feed flagged as a
+    personal best.  That flag is routinely absent in practice sessions and
+    in older seasons, in which case the default call returns None even
+    though the driver has perfectly good timed laps.  Fall back to picking
+    purely on lap time so we don't tell the user "no timed lap" when there
+    plainly is one.
+    """
+    if laps is None or not len(laps):
+        return None
+    try:
+        fast = laps.pick_fastest()
+    except Exception:
+        fast = None
+    if fast is None:
+        try:
+            fast = laps.pick_fastest(only_by_time=True)
+        except Exception:
+            fast = None
+    return fast
+
+
+def fastest_lap_number(session, abbr: str) -> Optional[int]:
+    try:
+        fast = _pick_fastest(session.laps.pick_drivers(abbr))
+    except Exception:
+        return None
+    if fast is None:
+        return None
+    try:
+        num = fast["LapNumber"]
+    except Exception:
+        return None
+    return None if pd.isna(num) else int(num)
+
+
+# ---------------------------------------------------------------------------
+# Lap telemetry
+# ---------------------------------------------------------------------------
+
+# Distance-grid resolution for a single lap.  ~5 m per sample on a typical
+# 5 km circuit, which is finer than the ~4 Hz raw car-data feed but keeps
+# the delta curve smooth on screen.
+LAP_GRID_POINTS = 1000
+
+
+def lap_telemetry(session, abbr: str, lap_number: Optional[int] = None,
+                  team_colors: Optional[dict] = None) -> LapTelemetry:
+    """Pull one lap and resample it onto an even distance grid.
+
+    `lap_number=None` picks the driver's fastest lap.  Raises ValueError
+    with a human-readable message if the lap or its telemetry is missing,
+    which the UI surfaces directly.
+    """
+    try:
+        laps = session.laps.pick_drivers(abbr)
+    except Exception as exc:
+        raise ValueError(f"No lap data for {abbr}: {exc}") from exc
+    if laps is None or not len(laps):
+        raise ValueError(f"{abbr} has no laps in this session.")
+
+    if lap_number is None:
+        lap = _pick_fastest(laps)
+        if lap is None:
+            raise ValueError(f"{abbr} set no timed lap in this session.")
+    else:
+        sel = laps[laps["LapNumber"] == float(lap_number)]
+        if not len(sel):
+            raise ValueError(f"{abbr} has no lap {lap_number}.")
+        lap = sel.iloc[0]
+
+    try:
+        car = lap.get_car_data()
+    except Exception as exc:
+        raise ValueError(
+            f"No car telemetry for {abbr} lap {lap_number or 'fastest'}: {exc}"
+        ) from exc
+    if car is None or not len(car):
+        raise ValueError(f"No car telemetry for {abbr} on that lap.")
+
+    car = car.add_distance()
+
+    dist = car["Distance"].to_numpy(dtype=np.float64)
+    elapsed = _to_seconds(car["Time"])
+    # add_distance() integrates speed from the first sample, so a lap whose
+    # telemetry starts mid-lap would carry an offset; normalise both axes.
+    if len(dist):
+        dist = dist - dist[0]
+    if len(elapsed):
+        elapsed = elapsed - elapsed[0]
+
+    total = float(dist[-1]) if len(dist) else 0.0
+    if total <= 0:
+        raise ValueError(f"Telemetry for {abbr} on that lap covers no distance.")
+
+    grid = np.linspace(0.0, total, LAP_GRID_POINTS)
+
+    def _cont(col):
+        if col not in car:
+            return np.full(grid.shape, np.nan, dtype=np.float32)
+        return _interp_continuous(grid, dist,
+                                  car[col].to_numpy(dtype=np.float64))
+
+    def _disc(col):
+        if col not in car:
+            return np.zeros(grid.shape, dtype=np.float32)
+        vals = car[col].to_numpy()
+        if vals.dtype == bool:
+            vals = vals.astype(np.float64)
+        return _interp_discrete(grid, dist, vals.astype(np.float64))
+
+    elapsed_grid = _interp_continuous(grid, dist, elapsed).astype(np.float64)
+
+    # Track map coordinates for the mini-sector overlay.  Position data is
+    # a separate stream at a different rate, so map it onto the same
+    # distance grid via the shared lap-relative time base.
+    xs = np.full(grid.shape, np.nan, dtype=np.float32)
+    ys = np.full(grid.shape, np.nan, dtype=np.float32)
+    try:
+        pos = lap.get_pos_data()
+    except Exception:
+        pos = None
+    if pos is not None and len(pos):
+        pos_t = _to_seconds(pos["Time"])
+        if len(pos_t):
+            pos_t = pos_t - pos_t[0]
+        xs = _interp_continuous(elapsed_grid, pos_t,
+                                pos["X"].to_numpy(dtype=np.float64))
+        ys = _interp_continuous(elapsed_grid, pos_t,
+                                pos["Y"].to_numpy(dtype=np.float64))
+
+    lt = lap.get("LapTime")
+    lt_s = None if lt is None or pd.isna(lt) else float(
+        pd.Timedelta(lt).total_seconds())
+    comp = lap.get("Compound")
+    comp = None if (comp is None or pd.isna(comp)) else str(comp)
+    team = str(lap.get("Team") or "")
+
+    drivers = {d.abbr: d for d in driver_table(session, team_colors)}
+    info = drivers.get(abbr)
+
+    event_name, year, rnd, circuit = _event_meta(session)
+
+    return LapTelemetry(
+        year=year, round_no=rnd, event=event_name,
+        session_code=_session_code(session),
+        session_name=session_display_name(session),
+        driver=abbr,
+        driver_name=info.name if info else abbr,
+        team=team or (info.team if info else ""),
+        color=(info.color if info else None) or
+              (team_colors or {}).get(team, "#8F8F98"),
+        lap_number=int(lap["LapNumber"]) if not pd.isna(lap.get("LapNumber")) else 0,
+        lap_time=lt_s,
+        compound=comp,
+        tyre_life=_nan_to_none(lap.get("TyreLife")),
+        circuit=circuit,
+        distance=grid.astype(np.float32),
+        elapsed=elapsed_grid.astype(np.float32),
+        speed=_cont("Speed"),
+        throttle=_cont("Throttle"),
+        brake=_disc("Brake"),
+        gear=_disc("nGear"),
+        rpm=_cont("RPM"),
+        drs=_disc("DRS"),
+        x=xs, y=ys,
+    )
+
+
+def _event_meta(session) -> tuple[str, int, int, str]:
+    name, year, rnd, circuit = "Grand Prix", 0, 0, ""
+    try:
+        ev = session.event
+        name = str(ev.get("EventName") or name)
+        circuit = str(ev.get("Location") or ev.get("Country") or "")
+        rnd = int(ev.get("RoundNumber") or 0)
+    except Exception:
+        pass
+    try:
+        year = int(session.event.year)
+    except Exception:
+        try:
+            year = int(session.date.year)
+        except Exception:
+            year = 0
+    return name, year, rnd, circuit
+
+
+def _session_code(session) -> str:
+    nm = session_display_name(session)
+    for code, label in SESSION_CHOICES:
+        if label == nm:
+            return code
+    return nm
+
+
+DEFAULT_MINISECTORS = 25
+
+
+def compare_laps(ref: LapTelemetry, other: LapTelemetry,
+                 minisectors: int = DEFAULT_MINISECTORS) -> Comparison:
+    """Align two laps on distance and derive the delta + sector dominance.
+
+    The laps do not need to share a session — only a circuit.  We clip to
+    the shorter of the two distance traces so a lap whose telemetry starts
+    slightly late doesn't drag the comparison off the end.
+    """
+    max_d = min(float(ref.distance[-1]), float(other.distance[-1]))
+    if max_d <= 0:
+        raise ValueError("Laps have no overlapping distance to compare.")
+
+    grid = np.linspace(0.0, max_d, LAP_GRID_POINTS)
+    ref_t = np.interp(grid, ref.distance, ref.elapsed)
+    oth_t = np.interp(grid, other.distance, other.elapsed)
+    delta = oth_t - ref_t
+
+    edges = np.linspace(0.0, max_d, minisectors + 1)
+    ref_at = np.interp(edges, ref.distance, ref.elapsed)
+    oth_at = np.interp(edges, other.distance, other.elapsed)
+    ref_seg = np.diff(ref_at)
+    oth_seg = np.diff(oth_at)
+    seg_delta = oth_seg - ref_seg
+    winner = (seg_delta > 0).astype(np.int8)  # other slower -> ref wins (0)
+
+    same = _same_circuit(ref, other)
+
+    return Comparison(
+        ref=ref, other=other,
+        distance=grid.astype(np.float32),
+        ref_elapsed=ref_t.astype(np.float32),
+        other_elapsed=oth_t.astype(np.float32),
+        delta=delta.astype(np.float32),
+        minisector_edges=edges.astype(np.float32),
+        minisector_winner=winner,
+        minisector_delta=seg_delta.astype(np.float32),
+        same_circuit=same,
+    )
+
+
+def _same_circuit(a: LapTelemetry, b: LapTelemetry) -> bool:
+    """Distance-aligned comparison is only meaningful on the same track.
+
+    Circuits get resurfaced and occasionally re-profiled between seasons,
+    so we compare the location name and allow a few percent of lap-length
+    drift rather than demanding an exact match.
+    """
+    if a.circuit and b.circuit and a.circuit.strip().lower() != b.circuit.strip().lower():
+        return False
+    la, lb = float(a.distance[-1]), float(b.distance[-1])
+    if la <= 0 or lb <= 0:
+        return False
+    return abs(la - lb) / max(la, lb) < 0.05
+
+
+# ---------------------------------------------------------------------------
+# Session replay
+# ---------------------------------------------------------------------------
+
+# 4 Hz gives visibly smooth motion once the UI interpolates between frames,
+# while keeping a two-hour race under ~30 k frames per driver.
+DEFAULT_REPLAY_HZ = 4.0
+
+# Centreline resolution used to project cars onto track progress.  240
+# points is ~20 m on a typical circuit — fine enough to order cars
+# correctly, coarse enough that the projection stays a couple of seconds
+# of numpy rather than a couple of minutes.
+CENTERLINE_POINTS = 240
+
+
+def _replay_cache_path(year: int, round_no: int, code: str, hz: float) -> Path:
+    key = f"{REPLAY_CACHE_VERSION}:{year}:{round_no}:{code}:{hz:g}"
+    digest = hashlib.sha1(key.encode()).hexdigest()[:16]
+    return REPLAY_CACHE_DIR / f"replay_{year}_{round_no}_{code}_{digest}.pkl"
+
+
+def load_cached_replay(year: int, round_no: int, code: str,
+                       hz: float = DEFAULT_REPLAY_HZ) -> Optional[Replay]:
+    path = _replay_cache_path(year, round_no, code, hz)
+    if not path.exists():
+        return None
+    try:
+        with open(path, "rb") as fh:
+            obj = pickle.load(fh)
+    except Exception:
+        # A truncated or stale pickle should never be fatal — just rebuild.
+        try:
+            path.unlink()
+        except Exception:
+            pass
+        return None
+    return obj if isinstance(obj, Replay) else None
+
+
+def _store_replay(rp: Replay) -> None:
+    path = _replay_cache_path(rp.year, rp.round_no, rp.session_code, rp.hz)
+    tmp = path.with_suffix(".tmp")
+    try:
+        with open(tmp, "wb") as fh:
+            pickle.dump(rp, fh, protocol=pickle.HIGHEST_PROTOCOL)
+        tmp.replace(path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except Exception:
+            pass
+
+
+def _build_centerline(session, pos_data: dict) -> tuple[np.ndarray, np.ndarray,
+                                                        np.ndarray, float]:
+    """Build a track centreline from the fastest lap's position trace.
+
+    The fastest lap is the cleanest single loop available: no pit entry, no
+    slow-down lap, no off-track excursion.
+    """
+    xs = ys = None
+    try:
+        fast = _pick_fastest(session.laps)
+        if fast is not None:
+            pos = fast.get_pos_data()
+            if pos is not None and len(pos) > 10:
+                xs = pos["X"].to_numpy(dtype=np.float64)
+                ys = pos["Y"].to_numpy(dtype=np.float64)
+    except Exception:
+        xs = ys = None
+
+    if xs is None or ys is None or len(xs) < 10:
+        # Fall back to the longest available position stream.
+        best = None
+        for df in pos_data.values():
+            if df is not None and len(df) > (0 if best is None else len(best)):
+                best = df
+        if best is None or not len(best):
+            return (np.zeros(0), np.zeros(0), np.zeros(0), 0.0)
+        xs = best["X"].to_numpy(dtype=np.float64)
+        ys = best["Y"].to_numpy(dtype=np.float64)
+
+    cx, cy, s = _resample_path(xs, ys, CENTERLINE_POINTS)
+    length = float(s[-1]) if len(s) else 0.0
+    return cx, cy, s, length
+
+
+def _project_progress(x: np.ndarray, y: np.ndarray,
+                      cx: np.ndarray, cy: np.ndarray,
+                      s: np.ndarray, chunk: int = 2048) -> np.ndarray:
+    """Arc-length position of each (x, y) sample along the centreline.
+
+    Done as a chunked full nearest-neighbour search: a windowed search
+    would be cheaper but breaks the moment a car leaves the track and
+    rejoins somewhere else, which happens in every race.
+    """
+    n = len(x)
+    out = np.zeros(n, dtype=np.float64)
+    if n == 0 or len(cx) == 0:
+        return out
+    for lo in range(0, n, chunk):
+        hi = min(n, lo + chunk)
+        dx = x[lo:hi, None] - cx[None, :]
+        dy = y[lo:hi, None] - cy[None, :]
+        idx = np.argmin(dx * dx + dy * dy, axis=1)
+        out[lo:hi] = s[idx]
+    return out
+
+
+def _run_length_compounds(grid: np.ndarray, lap_start: np.ndarray,
+                          compounds: Sequence) -> list:
+    """Per-frame compound, taken from the stint that owns each frame."""
+    if not len(lap_start) or not len(compounds):
+        return [None] * len(grid)
+    idx = np.searchsorted(lap_start, grid, side="right") - 1
+    np.clip(idx, 0, len(compounds) - 1, out=idx)
+    return [compounds[i] for i in idx]
+
+
+def build_replay(session, hz: float = DEFAULT_REPLAY_HZ,
+                 team_colors: Optional[dict] = None,
+                 progress: Optional[Callable[[str], None]] = None) -> Replay:
+    """Turn a loaded session into a scrubbable replay.
+
+    The session must have been loaded with `with_telemetry=True`.
+    """
+    def _say(msg):
+        if progress:
+            try:
+                progress(msg)
+            except Exception:
+                pass
+
+    pos_data = _safe_stream(session, "pos_data") or {}
+    car_data = _safe_stream(session, "car_data") or {}
+    if not pos_data:
+        raise ValueError(
+            "This session has no position data — replay needs the car "
+            "telemetry stream, which F1 only publishes for 2018 onwards."
+        )
+
+    laps = session.laps
+    infos = driver_table(session, team_colors)
+    if not infos:
+        raise ValueError("No drivers found in this session.")
+
+    _say("Building time grid…")
+
+    # -- common time grid -------------------------------------------------
+    starts, ends = [], []
+    for df in pos_data.values():
+        if df is None or not len(df) or "SessionTime" not in df:
+            continue
+        st = _to_seconds(df["SessionTime"])
+        st = st[np.isfinite(st)]
+        if len(st):
+            starts.append(st[0])
+            ends.append(st[-1])
+    if not starts:
+        raise ValueError("Position data carries no usable session timestamps.")
+
+    # Trim to the actual green-flag window where we can: the raw streams
+    # start well before the session does (formation, garage running) and a
+    # replay that opens on twenty stationary cars is a poor first frame.
+    t_start = float(min(starts))
+    t_end = float(max(ends))
+    try:
+        lap_starts = _to_seconds(laps["LapStartTime"])
+        lap_starts = lap_starts[np.isfinite(lap_starts)]
+        lap_ends = _to_seconds(laps["Time"])
+        lap_ends = lap_ends[np.isfinite(lap_ends)]
+        if len(lap_starts) and len(lap_ends):
+            t_start = max(t_start, float(np.min(lap_starts)) - 5.0)
+            t_end = min(t_end, float(np.max(lap_ends)) + 15.0)
+    except Exception:
+        pass
+    if not (t_end > t_start):
+        raise ValueError("Could not determine the session's time window.")
+
+    step = 1.0 / float(hz)
+    grid = np.arange(t_start, t_end + step, step, dtype=np.float64)
+
+    _say("Tracing the circuit…")
+    cx, cy, cs, track_len = _build_centerline(session, pos_data)
+    race_like = _session_code(session) in RACE_LIKE
+
+    drivers: list[ReplayDriver] = []
+    total = len(infos)
+    for i, info in enumerate(infos, start=1):
+        _say(f"Replaying {info.abbr} ({i}/{total})…")
+        num = info.number
+        pdf = pos_data.get(num)
+        if pdf is None or not len(pdf):
+            continue
+
+        pt = _to_seconds(pdf["SessionTime"])
+        px = pdf["X"].to_numpy(dtype=np.float64)
+        py = pdf["Y"].to_numpy(dtype=np.float64)
+
+        gx = _interp_continuous(grid, pt, px)
+        gy = _interp_continuous(grid, pt, py)
+
+        # Status is a string channel; hold the last known value.
+        if "Status" in pdf:
+            status = pdf["Status"].to_numpy()
+            on_num = (status == "OnTrack").astype(np.float64)
+            on_track = _interp_discrete(grid, pt, on_num) > 0.5
+        else:
+            on_track = np.ones(grid.shape, dtype=bool)
+        # Outside the driver's own data window they are not running.
+        if len(pt):
+            on_track &= (grid >= pt[0] - 1.0) & (grid <= pt[-1] + 1.0)
+
+        cdf = car_data.get(num)
+        if cdf is not None and len(cdf):
+            ct = _to_seconds(cdf["SessionTime"])
+
+            def _cc(col):
+                if col not in cdf:
+                    return np.full(grid.shape, np.nan, dtype=np.float32)
+                return _interp_continuous(
+                    grid, ct, cdf[col].to_numpy(dtype=np.float64))
+
+            def _cd(col):
+                if col not in cdf:
+                    return np.zeros(grid.shape, dtype=np.float32)
+                vals = cdf[col].to_numpy()
+                if vals.dtype == bool:
+                    vals = vals.astype(np.float64)
+                return _interp_discrete(grid, ct, vals.astype(np.float64))
+
+            speed, throttle, rpm = _cc("Speed"), _cc("Throttle"), _cc("RPM")
+            brake, gear, drs = _cd("Brake"), _cd("nGear"), _cd("DRS")
+        else:
+            nanv = np.full(grid.shape, np.nan, dtype=np.float32)
+            zerov = np.zeros(grid.shape, dtype=np.float32)
+            speed = throttle = rpm = nanv
+            brake = gear = drs = zerov
+
+        # -- laps completed, current lap, rolling best ---------------------
+        dl = laps[laps["Driver"] == info.abbr] if "Driver" in laps else laps.iloc[0:0]
+        lap_end = _to_seconds(dl["Time"]) if len(dl) else np.zeros(0)
+        lap_start = _to_seconds(dl["LapStartTime"]) if len(dl) else np.zeros(0)
+        lap_times = _to_seconds(dl["LapTime"]) if len(dl) else np.zeros(0)
+        comps = [None if pd.isna(c) else str(c)
+                 for c in (dl["Compound"] if len(dl) else [])]
+
+        valid = np.isfinite(lap_end)
+        ends_sorted = np.sort(lap_end[valid]) if valid.any() else np.zeros(0)
+        completed = np.searchsorted(ends_sorted, grid, side="right").astype(
+            np.float64)
+
+        # Rolling personal best: the best lap time among laps *finished* by
+        # each frame, so the quali timing screen updates as laps land.
+        if valid.any():
+            order = np.argsort(lap_end[valid], kind="stable")
+            lt_sorted = lap_times[valid][order]
+            lt_sorted = np.where(np.isfinite(lt_sorted), lt_sorted, np.inf)
+            running_best = np.minimum.accumulate(lt_sorted)
+            idx = np.searchsorted(ends_sorted, grid, side="right") - 1
+            best = np.where(idx >= 0,
+                            running_best[np.clip(idx, 0, len(running_best) - 1)],
+                            np.inf)
+        else:
+            best = np.full(grid.shape, np.inf)
+        best = np.where(np.isfinite(best), best, np.nan).astype(np.float32)
+
+        # -- track progress ------------------------------------------------
+        if track_len > 0 and race_like:
+            s_pos = _project_progress(gx.astype(np.float64),
+                                      gy.astype(np.float64), cx, cy, cs)
+            frac = s_pos / track_len
+            prog = completed + frac
+            # Projection noise around the start line can momentarily read as
+            # "nearly a full lap ahead" the instant after the counter ticks
+            # over.  Cars only ever move forwards, so clamp to monotonic.
+            prog = np.maximum.accumulate(prog)
+        else:
+            prog = completed.copy()
+        prog = prog.astype(np.float32)
+
+        lap_no = np.clip(completed + 1, 1, None).astype(np.int16)
+
+        # Pair each stint compound with the lap it started on, then sort the
+        # pair together — searchsorted needs an ascending key array and the
+        # compound list has to stay aligned with it.
+        if len(lap_start) and len(comps) == len(lap_start):
+            ok = np.isfinite(lap_start)
+            starts_valid = lap_start[ok]
+            comps_valid = [c for c, keep in zip(comps, ok) if keep]
+            order = np.argsort(starts_valid, kind="stable")
+            starts_valid = starts_valid[order]
+            comps_valid = [comps_valid[j] for j in order]
+        else:
+            starts_valid = np.zeros(0)
+            comps_valid = []
+        comp_seq = _run_length_compounds(grid, starts_valid, comps_valid)
+
+        finished_at = float(pt[-1]) if len(pt) else None
+
+        drivers.append(ReplayDriver(
+            info=info, x=gx, y=gy, progress=prog, on_track=on_track,
+            speed=speed, throttle=throttle, brake=brake, gear=gear,
+            rpm=rpm, drs=drs, lap_number=lap_no, compound=comp_seq,
+            best_lap=best, finished_at=finished_at,
+        ))
+
+    if not drivers:
+        raise ValueError("No driver had usable position data for this session.")
+
+    _say("Marking corners…")
+    corners = []
+    try:
+        ci = session.get_circuit_info()
+        if ci is not None and ci.corners is not None:
+            for _, row in ci.corners.iterrows():
+                letter = row.get("Letter") or ""
+                corners.append((float(row["X"]), float(row["Y"]),
+                                f"{int(row['Number'])}{letter}"))
+    except Exception:
+        corners = []
+
+    event_name, year, rnd, circuit = _event_meta(session)
+
+    rp = Replay(
+        year=year, round_no=rnd, event=event_name,
+        session_code=_session_code(session),
+        session_name=session_display_name(session),
+        circuit=circuit, hz=float(hz),
+        t=grid.astype(np.float32), drivers=drivers,
+        track_x=cx.astype(np.float32), track_y=cy.astype(np.float32),
+        track_length=track_len, corners=corners,
+        total_laps=_safe_total_laps(session), race_like=race_like,
+    )
+
+    _say("Caching replay…")
+    _store_replay(rp)
+    return rp
+
+
+def get_replay(year: int, round_no: int, code: str,
+               hz: float = DEFAULT_REPLAY_HZ,
+               team_colors: Optional[dict] = None,
+               progress: Optional[Callable[[str], None]] = None) -> Replay:
+    """Cached replay for a session, building it if we've not seen it."""
+    cached = load_cached_replay(year, round_no, code, hz)
+    if cached is not None:
+        if progress:
+            try:
+                progress("Loaded replay from cache.")
+            except Exception:
+                pass
+        return cached
+    session = load_session(year, round_no, code, with_telemetry=True,
+                           progress=progress)
+    return build_replay(session, hz=hz, team_colors=team_colors,
+                        progress=progress)


### PR DESCRIPTION
Replaces #14 — same work, rebuilt on a branch whose name and history carry no external product references.

## Summary

Two new console tabs built on the FastF1 feed ApexAI already runs on:

- **06 TELEMETRY** — overlay any two laps on a shared distance axis
- **07 SESSION REPLAY** — scrub any session frame-by-frame with a live track map, timing screen and telemetry HUD

Both sit on a new `telemetry.py` data layer.

## New module: `telemetry.py`

Pure data — no Tk, no matplotlib.

- `lap_telemetry()` pulls a lap's car data and resamples it onto an even **distance** grid.
- `compare_laps()` aligns two laps on that grid and derives the running delta plus mini-sector dominance. Alignment is by distance rather than wall-clock, which is what makes lap-vs-lap, compound-vs-compound and year-vs-year the *same* code path rather than three.
- `build_replay()` resamples every driver's position and car streams onto one common 4 Hz time grid, and projects each car onto the circuit centreline to give a continuous "laps completed + fraction of the current lap" value.
- `Replay.order_at()` turns that into a timing screen: races order by track progress with a real time gap to the leader; qualifying and practice order by best lap set so far, matching the real broadcast screens.
- Built replays are pickled to `replay_cache/` under a version-stamped key, so re-opening a session is instant and a schema change invalidates rather than mis-loads.

## UI changes in `app.py`

**06 TELEMETRY** — two independent season/round/session/driver/lap pickers. *LINK SESSIONS* is on by default for the common two-team-mates case; turn it off to compare across sessions and seasons. Renders lap summary cards, a headline delta, speed/delta/throttle/brake+DRS/gear traces, and a dominance map beside the per-sector time swing.

**07 SESSION REPLAY** — live track map traced from the session's own position data, timing screen, telemetry HUD for the focused car (click any timing row to follow that driver), and a transport with play/pause, 0.5×–16×, scrub and ±1 lap jumps. Car markers update per frame; the panels refresh at 5 Hz, since two dozen label rows can't be read at 25 fps anyway.

Both season selectors stop at **2018**, the first year with car and position telemetry in the feed.

## Three fixes found while testing

- `Laps.pick_fastest()` only considers laps the feed flagged as a personal best, and that flag is routinely absent in practice sessions and older seasons. It returned `None` there, which surfaced as "set no timed lap" for drivers who plainly had timed laps. Now falls back to picking purely on lap time.
- The timing screen's leader rendered a blank gap instead of `LEADER`, because the leader's gap was `None` rather than zero.
- FastF1 wraps each loader in `@soft_exceptions`, so a session whose timing data can't be fetched still returns normally from `load()` with nothing attached, and every later access dies on `DataNotLoadedError` deep in a helper. That reached the user as either "No drivers found in that session" — blaming the session for a network failure — or FastF1's raw "see `Session.load`" jargon. `load_session()` now checks the load actually produced laps and says plainly what went wrong. Related: `session.pos_data`/`car_data` *raise* when unloaded rather than returning `None`, so `build_replay()`'s `getattr(..., None)` guard would have propagated that error instead of raising the intended one.

## Testing

Verified with an offline suite that drives the real code paths against synthetic streams matching FastF1's actual schemas (real `Laps`/`Telemetry` objects on a stub session), generated from a closed-form model — circular track, each driver lapping at a known time — so every result has an analytic answer:

- **81 data checks** — the delta recovers the true lap-time difference, gap-to-leader tracks the real pace deficit, progress lands exactly on the lap count, quali orders by best lap, cache round-trips and degrades correctly on corruption
- **84 headless Tk checks** — both tabs end to end under Xvfb: picker population, LINK behaviour, both matplotlib figures, scene build, timing screen, HUD, playback tick, scrub, lap stepping, view-switch pausing, error paths
- Existing five tabs re-verified unchanged

## Known limitation

**This has not been exercised against live telemetry.** The environment this was built in cannot reach `livetiming.formula1.com` — only the calendar endpoint was reachable — so the synthetic fixtures are the whole story. They always have data, which is precisely why the third fix above was only found by pointing the app at a feed that fails.

Worth one local run against a real race before merging. The first thing I'd check is the running order during a safety car.

There is no CI on this repo, so nothing here runs automatically on the PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0124d9SLiDzTWwGe8Gjtj9eK)_